### PR TITLE
Add support for percentile timers

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -14,7 +14,7 @@
 
     // alignment rules
     "maximumLineLength": {
-        "value": 80,
+        "value": 100,
         "allowComments": true,
         "allowUrlComments": true,
         "allowRegex": true
@@ -60,14 +60,6 @@
     "requireLineBreakAfterVariableAssignment": true,
     "requirePaddingNewLinesAfterUseStrict": true,
     "requirePaddingNewLinesBeforeExport": true,
-    "requirePaddingNewlinesBeforeKeywords": [
-        "do",
-        "for",
-        "if",
-        "switch",
-        "try",
-        "while"
-    ],
     "requireSemicolons": true,
     "requireSpaceAfterBinaryOperators": true,
     "requireSpaceAfterKeywords": [

--- a/src/counter.js
+++ b/src/counter.js
@@ -28,7 +28,7 @@ class Counter {
     }
 
     this.count = 0;
-    return [{id: this.id.withStat('count'), v: c}];
+    return [{id: this.id.withDefaultStat('count'), v: c}];
   }
 }
 

--- a/src/gauge.js
+++ b/src/gauge.js
@@ -21,7 +21,7 @@ class Gauge {
     if (isNaN(v)) {
       return [];
     }
-    return [{id: this.id.withStat('gauge'), v: v}];
+    return [{id: this.id.withDefaultStat('gauge'), v: v}];
   }
 }
 

--- a/src/http.js
+++ b/src/http.js
@@ -38,7 +38,8 @@ class HttpClient {
       });
       res.on('end', () => {
         const statusFamily = `${Math.floor(res.statusCode / 100)}xx`;
-        self.registry.timer(baseId, {statusCode: res.statusCode, status: statusFamily}).record(process.hrtime(start));
+        const timerId = baseId.withTags({statusCode: res.statusCode, status: statusFamily});
+        self.registry.timer(timerId).record(process.hrtime(start));
 
         if (statusFamily !== '2xx') {
           log.error(`POST to ${endpoint}: ${res.statusCode} - ${data}`);
@@ -56,7 +57,8 @@ class HttpClient {
         // the error message
         log.error(`problem with request: ${e.message}`);
       }
-      self.registry.timer(baseId, {statusCode: error, status: error}).record(process.hrtime(start));
+      self.registry.timer(baseId, {statusCode: error, status: error})
+        .record(process.hrtime(start));
     });
 
     const timeout = this.registry.config.timeout || 1000;

--- a/src/meter_id.js
+++ b/src/meter_id.js
@@ -64,6 +64,13 @@ class MeterId {
   withStat(stat) {
     return this.withTag('statistic', stat);
   }
+
+  withDefaultStat(stat) {
+    if (this.tags.has('statistic')) {
+      return this;
+    }
+    return this.withTag('statistic', stat);
+  }
 }
 
 module.exports = MeterId;

--- a/src/percentile_buckets.js
+++ b/src/percentile_buckets.js
@@ -1,0 +1,137 @@
+'use strict';
+
+const bucketValues = [];
+const LONG_MAX_VALUE = 0x7fffffffffffffff;
+
+function initialize() {
+  const DIGITS = 2;
+  bucketValues.push(1, 2, 3);
+
+  let exp = DIGITS;
+
+  while (exp < 56) {
+    let current = Math.pow(2, exp);
+    const delta = Math.floor(current / 3);
+    let next = current * 4 - delta;
+
+    while (current < next) {
+      bucketValues.push(current);
+      current += delta;
+    }
+    exp += DIGITS;
+  }
+  // unfortunately we only get 56 bits of precision so
+  // we generated this table with our C++ implementation
+  // following the above algorithm
+  bucketValues.push(66052794534767272);
+  bucketValues.push(72057594037927936);
+  bucketValues.push(96076792050570581);
+  bucketValues.push(120095990063213226);
+  bucketValues.push(144115188075855871);
+  bucketValues.push(168134386088498516);
+  bucketValues.push(192153584101141161);
+  bucketValues.push(216172782113783806);
+  bucketValues.push(240191980126426451);
+  bucketValues.push(264211178139069096);
+  bucketValues.push(288230376151711744);
+  bucketValues.push(384307168202282325);
+  bucketValues.push(480383960252852906);
+  bucketValues.push(576460752303423487);
+  bucketValues.push(672537544353994068);
+  bucketValues.push(768614336404564649);
+  bucketValues.push(864691128455135230);
+  bucketValues.push(960767920505705811);
+  bucketValues.push(1056844712556276392);
+  bucketValues.push(1152921504606846976);
+  bucketValues.push(1537228672809129301);
+  bucketValues.push(1921535841011411626);
+  bucketValues.push(2305843009213693951);
+  bucketValues.push(2690150177415976276);
+  bucketValues.push(3074457345618258601);
+  bucketValues.push(3458764513820540926);
+  bucketValues.push(3843071682022823251);
+  bucketValues.push(4227378850225105576);
+  bucketValues.push(LONG_MAX_VALUE);
+}
+
+initialize();
+
+function indexOf(v) {
+  if (v <= 0) {
+    return 0;
+  } else if (v <= 15) {
+    return v;
+  }
+
+  // binary search for the right spot
+  let minIndex = 15;
+  let maxIndex = bucketValues.length - 1;
+  while (minIndex < maxIndex) {
+    const mid = (minIndex + maxIndex) >>> 1;
+    const computed = bucketValues[mid];
+    if (computed < v) {
+      minIndex = mid + 1;
+    } else if (computed === v) {
+      return mid + 1;
+    } else {
+      maxIndex = mid;
+    }
+  }
+  return maxIndex;
+}
+
+function bucket(v) {
+  return bucketValues[indexOf(v)];
+}
+
+function percentiles(counts, pcts) {
+  let total = 0;
+  for (let c of counts) {
+    total += c;
+  }
+
+  let pctIdx = 0;
+  let prev = 0;
+  let prevP = 0.0;
+  let prevB = 0;
+  let results = new Array(pcts.length);
+  let i = 0;
+  for (let c of counts) {
+    const next = prev + c;
+    const nextP = 100.0 * next / total;
+    const nextB = bucketValues[i];
+    i++;
+    while (pctIdx < pcts.length && nextP >= pcts[pctIdx]) {
+      const f = (pcts[pctIdx] - prevP) / (nextP - prevP);
+      results[pctIdx] = f * (nextB - prevB) + prevB;
+      ++pctIdx;
+    }
+    if (pctIdx >= pcts.length) {
+      break;
+    }
+    prev = next;
+    prevP = nextP;
+    prevB = nextB;
+  }
+
+  const nextP = 100.0;
+  while (pctIdx < pcts.length) {
+    const f = (pcts[pctIdx] - prevP) / (nextP - prevP);
+    results[pctIdx] = f * (LONG_MAX_VALUE - prevB) + prevB;
+    ++pctIdx;
+  }
+
+  return results;
+}
+
+module.exports = {
+  length: () => {
+    return bucketValues.length;
+  },
+  bucket: bucket,
+  percentiles: percentiles,
+  maxValue: () => {
+    return LONG_MAX_VALUE;
+  },
+  indexOf: indexOf
+};

--- a/src/percentile_timer.js
+++ b/src/percentile_timer.js
@@ -1,0 +1,157 @@
+'use strict';
+
+const PercentileBuckets = require('./percentile_buckets');
+
+const percentiles = new Array(PercentileBuckets.length());
+for (let i = 0; i < percentiles.length; ++i) {
+  let hex = i.toString(16);
+  const hexLen = hex.length;
+  const zerosNeeded = 4 - hexLen;
+  for (let z = 0; z < zerosNeeded; ++z) {
+    hex = '0' + hex;
+  }
+  percentiles[i] = 'T' + hex;
+}
+
+/**
+ * Timer that buckets the counts to allow for estimating percentiles. This timer type will track
+ * the data distribution for the timer by maintaining a set of counters. The distribution
+ * can then be used on the server side to estimate percentiles while still allowing for
+ * arbitrary slicing and dicing based on dimensions.
+ *
+ * <p><b>Percentile timers are expensive compared to basic timers from the registry.</b> In
+ * particular they have a higher storage cost, worst case ~300x, to maintain the data
+ * distribution. Be diligent about any additional dimensions added to percentile timers and
+ * ensure they have a small bounded cardinality. In addition it is highly recommended to
+ * set a range (see {@link Builder#withRange(long, long, TimeUnit)}) whenever possible to
+ * greatly restrict the worst case overhead.</p>
+ *
+ * <p>When using the builder ({@link #builder(Registry)}), the range will default from 10 ms
+ * to 1 minute. Based on data at Netflix this is the most common range for request latencies
+ * and restricting to this window reduces the worst case multiple from 276 to 58</p>
+ */
+class PercentileTimer {
+  /**
+   * Creates a timer object that can be used for estimating percentiles. <b>Percentile timers
+   * are expensive compared to basic timers from the registry.</b> Be diligent with ensuring
+   * that any additional dimensions have a small bounded cardinality. It is also highly
+   * recommended to explicitly set a range
+   *
+   * @param {registry} registry spectator registry to use
+   * @param {id} id meter id
+   * @param {number} min minimum number of nanoseconds (default 0)
+   * @param {number} max maximum number of nanoseconds (default 2^63 - 1)
+   */
+  constructor(registry, id, min, max) {
+    this.registry = registry;
+    this.id = id;
+    this.timer = registry.timer(id);
+    this.min = min || 0;
+    this.max = max || PercentileBuckets.maxValue();
+    this.counters = new Array(PercentileBuckets.length());
+  }
+
+  static get Builder() {
+    class Builder {
+      constructor(registry) {
+        this.registry = registry;
+      }
+      withId(id) {
+        this.id = id;
+        return this;
+      }
+      withName(name) {
+        this.name = name;
+        return this;
+      }
+      withTags(tags) {
+        this.tags = tags;
+        return this;
+      }
+      withRangeSeconds(min, max) {
+        this.min = min * 1e9;
+        this.max = max * 1e9;
+        return this;
+      }
+      withRangeMilliseconds(min, max) {
+        this.min = min * 1e6;
+        this.max = max * 1e6;
+        return this;
+      }
+      withRangeNanoseconds(min, max) {
+        this.min = min;
+        this.max = max;
+        return this;
+      }
+      build() {
+        let id;
+        if (this.id) {
+          id = this.id;
+        } else {
+          id = this.registry.newId(this.name, this.tags);
+        }
+        return new PercentileTimer(this.registry, id, this.min, this.max);
+      }
+    }
+    return Builder;
+  }
+
+  _counterFor(i) {
+    let c = this.counters[i];
+    if (!c) {
+      const counterId = this.id.withTags(
+        {statistic: 'percentile', percentile: percentiles[i]});
+      c = this.registry.counter(counterId);
+      this.counters[i] = c;
+    }
+    return c;
+  }
+
+  _restrict(amount) {
+    const v = Math.min(amount, this.max);
+    return Math.max(v, this.min);
+  }
+
+  record(seconds, nanos) {
+    let actualNanos;
+    let actualSeconds;
+
+    // handle record(0, 100) and record([0, 100])
+    if (seconds instanceof Array) {
+      actualSeconds = seconds[0] || 0;
+      actualNanos = seconds[1] || 0;
+    } else {
+      actualSeconds = seconds || 0;
+      actualNanos = nanos || 0;
+    }
+
+    const totalNanos = actualSeconds * 1e9 + actualNanos;
+    const restrictedNanos = this._restrict(totalNanos);
+    this.timer.record(0, restrictedNanos);
+    this._counterFor(PercentileBuckets.indexOf(restrictedNanos)).increment();
+  }
+
+  /**
+   * Computes the percentile for this timer. The unit will be in seconds.
+   * @param {number} p -- Percentile to compute
+   * @returns {number} An approximation of the `p`th percentile in seconds.
+   */
+  percentile(p) {
+    const counts = new Array(PercentileBuckets.length());
+    for (let i = 0; i < counts.length; ++i) {
+      counts[i] = this._counterFor(i).count;
+    }
+    const ps = PercentileBuckets.percentiles(counts, [p]);
+    return ps[0] / 1e9;
+  }
+
+  get count() {
+    return this.timer.count;
+  }
+
+  get totalTime() {
+    return this.timer.totalTime;
+  }
+}
+
+module.exports = PercentileTimer;

--- a/src/timer.js
+++ b/src/timer.js
@@ -18,7 +18,7 @@ class Timer {
     const ns = nanos || 0;
 
     if (seconds instanceof Array) {
-      totalNanos = seconds[0] * 1e9 + seconds[1];
+      totalNanos = seconds[0] * 1e9 + (seconds[1] || 0);
     } else {
       totalNanos = seconds * 1e9 + ns;
     }

--- a/test/meter_id.test.js
+++ b/test/meter_id.test.js
@@ -49,4 +49,9 @@ describe('MeterIds', () => {
     assert.equal(id.key, 'name|k=v');
   });
 
+  it('should preserve statistic if present', () => {
+    const id = new MeterId('name', {statistic: 'percentile'});
+    assert.equal(id.withDefaultStat('counter').tags.get('statistic'), 'percentile');
+  });
+
 });

--- a/test/percentile_buckets.test.js
+++ b/test/percentile_buckets.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const chai = require('chai');
+const assert = chai.assert;
+const PercentileBuckets = require('../src/percentile_buckets');
+
+describe('Percentile Buckets', () => {
+  it('should get the right index', () => {
+    assert.equal(PercentileBuckets.indexOf(-1), 0);
+    for (let i = 0; i <= 4; ++i) {
+      assert.equal(PercentileBuckets.indexOf(i), i);
+    }
+    assert.equal(16, PercentileBuckets.indexOf(21));
+    assert.equal(18, PercentileBuckets.indexOf(31));
+    assert.equal(25, PercentileBuckets.indexOf(87));
+    assert.equal(41, PercentileBuckets.indexOf(1020));
+    assert.equal(55, PercentileBuckets.indexOf(10000));
+    assert.equal(70, PercentileBuckets.indexOf(100000));
+    assert.equal(86, PercentileBuckets.indexOf(1e6));
+    assert.equal(100, PercentileBuckets.indexOf(1e7));
+    assert.equal(115, PercentileBuckets.indexOf(1e8));
+    assert.equal(131, PercentileBuckets.indexOf(1e9));
+    assert.equal(144, PercentileBuckets.indexOf(1e10));
+    assert.equal(160, PercentileBuckets.indexOf(1e11));
+    assert.equal(175, PercentileBuckets.indexOf(1e12));
+
+    // assert.equal(PercentileBuckets.length() - 1,
+    //   PercentileBuckets.indexOf(Math.pow(2, 63)));
+  });
+
+  it('should compute sane bucket values', () => {
+    function getNumber() {
+      const Max = 1e14; // 10000s
+      return Math.floor(Math.random() * Max);
+    }
+
+    for (let i = 0; i < 10000; ++i) {
+      const n = getNumber();
+      const b = PercentileBuckets.bucket(n);
+      assert.isAtMost(n, b);
+    }
+  });
+
+  it('calculate percentiles', () => {
+    const counts = new Array(PercentileBuckets.length());
+    for (let i = 0; i < counts.length; ++i) {
+      counts[i] = 0;
+    }
+
+    for (let i = 0; i < 100000; ++i) {
+      ++counts[PercentileBuckets.indexOf(i)];
+    }
+
+    const pcts = [0.0,  25.0, 50.0, 75.0, 90.0, 95.0, 98.0, 99.0, 99.5, 100.0];
+    const expected = [0.0,  25e3, 50e3, 75e3,   90e3,
+      95e3, 98e3, 99e3, 99.5e3, 100e3];
+    const results = PercentileBuckets.percentiles(counts, pcts);
+    for (let i = 0; i < results.length; ++i) {
+      const threshold = 0.1 * expected[i];
+      assert.isAtMost(Math.abs(expected[i] - results[i]), threshold);
+    }
+  });
+
+});

--- a/test/percentile_timer.test.js
+++ b/test/percentile_timer.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const chai = require('chai');
+const assert = chai.assert;
+const Registry = require('../src/registry');
+const PercentileTimer = require('../src/percentile_timer');
+
+describe('Percentile Timers', () => {
+  function millisToNanos(millis) {
+    return millis * 1e6;
+  }
+
+  function checkPercentiles(timer, start) {
+    const N = 100000;
+    for (let i = 0; i < N; ++i) {
+      timer.record(0, millisToNanos(i));
+    }
+    assert.equal(timer.count, N);
+
+    for (let i = start; i <= 100; ++i) {
+      const expected = i;
+      const threshold = 0.15 * expected;
+      const actual = timer.percentile(i);
+      assert.isAtMost(Math.abs(expected - actual), threshold,
+        `Expected ${i}th percentile to be near ${expected} but got ${actual} instead`);
+    }
+  }
+
+  it('basic use', () => {
+    const r = new Registry();
+    const id = r.newId('p');
+    const t = new PercentileTimer(r, id);
+    checkPercentiles(t, 0);
+  });
+
+  it('builder with range', () => {
+    const r = new Registry();
+    const t = new PercentileTimer.Builder(r).withName('foo')
+      .withRangeSeconds(10, 100).build();
+    checkPercentiles(t, 10);
+  });
+
+  it('builder with threshold', () => {
+    const r = new Registry();
+    const t = new PercentileTimer.Builder(r).withName('foo')
+      .withRangeMilliseconds(0, 100 * 1000).build();
+    checkPercentiles(t, 0);
+  });
+
+  it('builder with nanos', () => {
+    const r = new Registry();
+    // 5ms to 100s
+    const t = new PercentileTimer.Builder(r).withName('foo')
+      .withRangeNanoseconds(5 * 1e6, 100 * 1e9).build();
+    checkPercentiles(t, 5);
+  });
+
+  it('builder with id', () => {
+    const r = new Registry();
+    const t = new PercentileTimer.Builder(r).withId(r.newId('name', {k: 'v'})).build();
+    assert.equal(t.id.key, 'name|k=v');
+  });
+
+  it('builder with name/tags', () => {
+    const r = new Registry();
+    const t = new PercentileTimer.Builder(r).withName('name').withTags({k: 'v'}).build();
+    assert.equal(t.id.key, 'name|k=v');
+  });
+
+  it('count and totalTime', () => {
+    const N = 10000;
+
+    // in milliseconds
+    const expectedSum = N * (N - 1) / 2;
+
+    const r = new Registry();
+    const timer = new PercentileTimer.Builder(r).withName('name').build();
+    for (let i = 0; i < N; ++i) {
+      timer.record([0, millisToNanos(i)]);
+    }
+
+    // totalTime returns nanos
+    assert.equal(timer.totalTime, expectedSum * 1e6);
+    assert.equal(timer.count, N);
+  });
+});

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -149,8 +149,7 @@ describe('AtlasRegistry', () => {
 
   function payloadToEntries(payload) {
     const numStrings = payload[0];
-    const strings = [];
-    strings.length = numStrings;
+    const strings = new Array(numStrings);
 
     for (let i = 1; i <= numStrings; ++i) {
       strings[i - 1] = payload[i];


### PR DESCRIPTION
Adds support for percentile timers: timers that bucket the counts for
different durations in order to allow estimating percentiles.