### PR TITLE
Add Bucket Meters:

### DIFF
--- a/src/bucket_counter.js
+++ b/src/bucket_counter.js
@@ -1,0 +1,31 @@
+'use strict';
+
+/** Counters that get incremented based on the bucket for recorded values. */
+class BucketCounter {
+  /**
+   * Creates a distribution summary object that manages a set of counters based on the bucket
+   * function supplied. Calling record will increment the appropriate counter.
+   *
+   * @param {registry} registry
+   *     Registry to use.
+   * @param {id} id
+   *     Identifier for the metric being registered.
+   * @param {function} bucketFunction
+   *     Function to map values to buckets. See {@link BucketFunctions} for more information.
+   */
+  constructor(registry, id, bucketFunction) {
+    this.registry = registry;
+    this.id = id;
+    this.bucketFunction = bucketFunction;
+  }
+
+  _counter(bucket) {
+    return this.registry.counter(this.id.withTag('bucket', bucket));
+  }
+
+  record(amount) {
+    this._counter(this.bucketFunction(amount)).increment();
+  }
+}
+
+module.exports = BucketCounter;

--- a/src/bucket_dist_summary.js
+++ b/src/bucket_dist_summary.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/** Distribution summaries that get updated based on the bucket for recorded values. */
+class BucketDistributionSummary {
+  /**
+   * Creates a distribution summary object that manages a set of distribution summaries based on
+   * the bucket function supplied. Calling record will be mapped to the record on the appropriate
+   * distribution summary.
+   *
+   * @param {registry} registry
+   *     Registry to use.
+   * @param {id} id
+   *     Identifier for the metric being registered.
+   * @param {function} bucketFunction
+   *     Function to map values to buckets. See {@link BucketFunctions} for more information.
+   */
+  constructor(registry, id, bucketFunction) {
+    this.registry = registry;
+    this.id = id;
+    this.bucketFunction = bucketFunction;
+  }
+
+  _distSummary(bucket) {
+    return this.registry.distributionSummary(this.id.withTag('bucket', bucket));
+  }
+
+  record(amount) {
+    this._distSummary(this.bucketFunction(amount)).record(amount);
+  }
+}
+
+module.exports = BucketDistributionSummary;

--- a/src/bucket_functions.js
+++ b/src/bucket_functions.js
@@ -1,0 +1,327 @@
+'use strict';
+
+const LONG_MAX_VALUE = 0x7fffffffffffffff;
+const BINARY_FORMATTERS = [];
+const DECIMAL_FORMATTERS = [];
+const TIME_FORMATTERS = [];
+
+function toNanos(amount, unit) {
+  switch (unit) {
+    case 'ns':
+      return amount;
+    case 'us':
+      return amount * 1e3;
+    case 'ms':
+      return amount * 1e6;
+    case 's':
+      return amount * 1e9;
+    case 'min':
+      return amount * 60 * 1e9;
+    case 'h':
+      return amount * 60 * 60 * 1e9;
+    case 'd':
+      return amount * 24 * 60 * 60 * 1e9;
+    default:
+      // should we throw?
+      return 0;
+  }
+}
+
+function fromNanos(amount, unit) {
+  switch (unit) {
+    case 'ns':
+      return amount;
+    case 'us':
+      return Math.floor(amount / 1e3);
+    case 'ms':
+      return Math.floor(amount / 1e6);
+    case 's':
+      return Math.floor(amount / 1e9);
+    case 'min':
+      return Math.floor(amount / (60 * 1e9));
+    case 'h':
+      return Math.floor(amount / (60 * 60 * 1e9));
+    case 'd':
+      return Math.floor(amount / (24 * 60 * 60 * 1e9));
+    default:
+      // should we throw?
+      return 0;
+  }
+}
+
+function zeroPad(width, suffix, v) {
+  const amount = Math.floor(v).toString(10);
+  const zerosNeeded = width - amount.length;
+  let result = amount;
+  for (let i = 0; i < zerosNeeded; ++i) {
+    result = '0' + result;
+  }
+  return result + suffix;
+}
+
+function valueFormatter(max, width, suffix, cnv) {
+  return {
+    max: max,
+    newBucket: (v) => {
+      return { name: zeroPad(width, suffix, cnv(v)), upperBoundary: v};
+    }
+  };
+}
+
+
+(function setupFormatters() {
+  function fmt(max, width, unit) {
+    return valueFormatter(max, width, unit, (v) => fromNanos(v, unit));
+  }
+
+  function bin(max, pow, width, suffix) {
+    const factor = Math.pow(2, pow * 10);
+    const maxBytes = max * factor;
+    return valueFormatter(maxBytes, width, suffix, (v) => v / factor);
+  }
+
+  function dec(max, pow, width, suffix) {
+    const factor = Math.pow(10, pow);
+    const maxBytes = max * factor;
+    return valueFormatter(maxBytes, width, suffix, (v) => v / factor);
+  }
+
+  TIME_FORMATTERS.push(fmt(10, 1,  'ns'));
+  TIME_FORMATTERS.push(fmt(100, 2, 'ns'));
+  TIME_FORMATTERS.push(fmt(1e3, 3, 'ns'));
+  TIME_FORMATTERS.push(fmt(8 * 1e3, 4, 'ns'));
+
+  TIME_FORMATTERS.push(fmt(10 * 1e3, 1, 'us'));
+  TIME_FORMATTERS.push(fmt(100 * 1e3, 2, 'us'));
+  TIME_FORMATTERS.push(fmt(1e6, 3, 'us'));
+  TIME_FORMATTERS.push(fmt(8 * 1e6, 4, 'us'));
+
+  TIME_FORMATTERS.push(fmt(10 * 1e6, 1, 'ms'));
+  TIME_FORMATTERS.push(fmt(100 * 1e6, 2, 'ms'));
+  TIME_FORMATTERS.push(fmt(1e9, 3, 'ms'));
+  TIME_FORMATTERS.push(fmt(8 * 1e9, 4, 'ms'));
+
+  TIME_FORMATTERS.push(fmt(10 * 1e9, 1, 's'));
+  TIME_FORMATTERS.push(fmt(100 * 1e9, 2, 's'));
+  TIME_FORMATTERS.push(fmt(toNanos(8, 'min'), 4, 's'));
+
+  TIME_FORMATTERS.push(fmt(toNanos(10, 'min'), 1, 'min'));
+  TIME_FORMATTERS.push(fmt(toNanos(100, 'min'), 2, 'min'));
+  TIME_FORMATTERS.push(fmt(toNanos(8, 'h'), 3, 'min'));
+  TIME_FORMATTERS.push(fmt(toNanos(10, 'h'), 1, 'h'));
+  TIME_FORMATTERS.push(fmt(toNanos(100, 'h'), 2, 'h'));
+  TIME_FORMATTERS.push(fmt(toNanos(8, 'd'), 3, 'h'));
+  TIME_FORMATTERS.push(fmt(toNanos(10, 'd'), 1, 'd'));
+  TIME_FORMATTERS.push(fmt(toNanos(100, 'd'), 2, 'd'));
+  TIME_FORMATTERS.push(fmt(toNanos(1000, 'd'), 3, 'd'));
+  TIME_FORMATTERS.push(fmt(toNanos(10000, 'd'), 4, 'd'));
+  TIME_FORMATTERS.push(fmt(toNanos(100000, 'd'), 5, 'd'));
+  TIME_FORMATTERS.push(fmt(LONG_MAX_VALUE, 6, 'd'));
+
+
+  const binaryUnits = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB'];
+  for (let i = 0; i < binaryUnits.length; ++i) {
+    BINARY_FORMATTERS.push(bin(10,    i, 1, '_' + binaryUnits[i]));
+    BINARY_FORMATTERS.push(bin(100,   i, 2, '_' + binaryUnits[i]));
+    BINARY_FORMATTERS.push(bin(1000,  i, 3, '_' + binaryUnits[i]));
+    BINARY_FORMATTERS.push(bin(10000, i, 4, '_' + binaryUnits[i]));
+  }
+
+  const decimalUnits = ['', '_k', '_M', '_G', '_T', '_P'];
+  for (let i = 0; i < decimalUnits.length; ++i) {
+    const pow = i * 3;
+    DECIMAL_FORMATTERS.push(dec(10,   pow, 1, decimalUnits[i]));
+    DECIMAL_FORMATTERS.push(dec(100,  pow, 2, decimalUnits[i]));
+    DECIMAL_FORMATTERS.push(dec(1000, pow, 3, decimalUnits[i]));
+    DECIMAL_FORMATTERS.push(dec(10000, pow, 4, decimalUnits[i]));
+  }
+}());
+
+function getFormatter(fmts, max) {
+  for (let f of fmts) {
+    if (max < f.max) {
+      return f;
+    }
+  }
+
+  return fmts[fmts.length - 1];
+}
+
+function bucketFunction(buckets, fallback) {
+  return function(amount) {
+    for (let b of buckets) {
+      if (amount <= b.upperBoundary) {
+        return b.name;
+      }
+    }
+    return fallback;
+  };
+}
+
+function biasZero(ltZero, gtMax, max, fmt) {
+  const buckets = new Array(5);
+  buckets[0] = {name: ltZero, upperBoundary: -1};
+  buckets[1] = fmt.newBucket(max / 8);
+  buckets[2] = fmt.newBucket(max / 4);
+  buckets[3] = fmt.newBucket(max / 2);
+  buckets[4] = fmt.newBucket(max);
+  return bucketFunction(buckets, gtMax);
+}
+
+function biasMax(ltZero, gtMax, max, fmt) {
+  const buckets = new Array(5);
+  buckets[0] = {name: ltZero, upperBoundary: -1};
+  buckets[1] = fmt.newBucket(max - max / 2);
+  buckets[2] = fmt.newBucket(max - max / 4);
+  buckets[3] = fmt.newBucket(max - max / 8);
+  buckets[4] = fmt.newBucket(max);
+  return bucketFunction(buckets, gtMax);
+}
+
+function timeBias(biasFun, ltZero, gtMax, max, unit) {
+  const v = toNanos(max, unit);
+  const fmt = getFormatter(TIME_FORMATTERS, v);
+  return biasFun(ltZero, gtMax, v, fmt);
+}
+
+function timeBiasZero(ltZero, gtMax, max, unit) {
+  return timeBias(biasZero, ltZero, gtMax, max, unit);
+}
+
+function timeBiasMax(ltZero, gtMax, max, unit) {
+  return timeBias(biasMax, ltZero, gtMax, max, unit);
+}
+
+/**
+ * Returns a function that maps age values to a set of buckets. Example use-case would be
+ * tracking the age of data flowing through a processing pipeline. Values that are less than
+ * 0 will be marked as "future". These typically occur due to minor variations in the clocks
+ * across nodes. In addition to a bucket at the max, it will create buckets at max / 2, max / 4,
+ * and max / 8.
+ *
+ * @param {number} max
+ *     Maximum expected age of data flowing through. Values greater than this max will be mapped
+ *     to an "old" bucket.
+ * @param {string} unit
+ *     Unit for the max value: 'd', 'h', 'min', 's', 'ms', 'us', 'ns'
+ * @return {function}
+ *     Function mapping age values to string labels. The labels for buckets will sort
+ *     so they can be used with a simple group by.
+ */
+function age(max, unit) {
+  return timeBiasZero('future', 'old', max, unit);
+}
+
+/**
+ * Returns a function that maps age values to a set of buckets. Example use-case would be
+ * tracking the age of data flowing through a processing pipeline. Values that are less than
+ * 0 will be marked as "future". These typically occur due to minor variations in the clocks
+ * across nodes. In addition to a bucket at the max, it will create buckets at max - max / 8,
+ * max - max / 4, and max - max / 2.
+ *
+ * @param {number} max
+ *     Maximum expected age of data flowing through. Values greater than this max will be mapped
+ *     to an "old" bucket.
+ * @param {string} unit
+ *     Unit for the max value: 'd', 'h', 'min', 's', 'ms', 'us', 'ns'
+ * @return {function}
+ *     Function mapping age values to string labels. The labels for buckets will sort
+ *     so they can be used with a simple group by.
+ */
+function ageBiasOld(max, unit) {
+  return timeBiasMax('future', 'old', max, unit);
+}
+
+/**
+ * Returns a function that maps size values in bytes to a set of buckets. The buckets will
+ * use <a href="https://en.wikipedia.org/wiki/Binary_prefix">binary prefixes</a> representing
+ * powers of 1024. If you want powers of 1000, then see decimal
+ *
+ * @param {number} max
+ *     Maximum expected size of data being recorded. Values greater than this amount will be
+ *     mapped to a "large" bucket.
+ * @return {function}
+ *     Function mapping size values to string labels. The labels for buckets will sort
+ *     so they can be used with a simple group by.
+ */
+function bytes(max) {
+  const f = getFormatter(BINARY_FORMATTERS, max);
+  return biasZero('negative', 'large', max, f);
+}
+
+/**
+ * Returns a function that maps latencies to a set of buckets. Example use-case would be
+ * tracking the amount of time to process a request on a server. Values that are less than
+ * 0 will be marked as "negative_latency". These typically occur due to minor variations in the
+ * clocks to measure the latency and having a
+ * time adjustment between the start and end. In addition to a bucket at the max, it will create
+ * buckets at max / 2, max / 4, and max / 8.
+ *
+ * @param {number} max
+ *     Maximum expected age of data flowing through. Values greater than this max will be mapped
+ *     to an "old" bucket.
+ * @param {string} unit
+ *     Unit for the max value: 'd', 'h', 'min', 's', 'ms', 'us', 'ns'
+ * @return {function}
+ *     Function mapping age values to string labels. The labels for buckets will sort
+ *     so they can be used with a simple group by.
+ */
+function latency(max, unit) {
+  return timeBiasZero('negative_latency', 'slow', max, unit);
+}
+
+/**
+ * Returns a function that maps latencies to a set of buckets. Example use-case would be
+ * tracking the amount of time to process a request on a server. Values that are less than
+ * 0 will be marked as "negative_latency". These typically occur due to minor variations in the
+ * clocks to measure the latency and having a
+ * time adjustment between the start and end. In addition to a bucket at the max, it will create
+ * buckets at max - max / 8, max - max / 4, and max - max / 2.
+ *
+ * @param {number} max
+ *     Maximum expected age of data flowing through. Values greater than this max will be mapped
+ *     to an "old" bucket.
+ * @param {string} unit
+ *     Unit for the max value: 'd', 'h', 'min', 's', 'ms', 'us', 'ns'
+ * @return {function}
+ *     Function mapping age values to string labels. The labels for buckets will sort
+ *     so they can be used with a simple group by.
+ */
+function latencyBiasSlow(max, unit) {
+  return timeBiasMax('negative_latency', 'slow', max, unit);
+}
+
+/**
+ * Returns a function that maps size values to a set of buckets. The buckets will
+ * use <a href="https://en.wikipedia.org/wiki/Metric_prefix">decimal prefixes</a> representing
+ * powers of 1000. If you are measuring quantities in bytes and want powers of 1024, then see
+ * bytes
+ *
+ * @param {number} max
+ *     Maximum expected size of data being recorded. Values greater than this amount will be
+ *     mapped to a "large" bucket.
+ * @return {function}
+ *     Function mapping size values to string labels. The labels for buckets will sort
+ *     so they can be used with a simple group by.
+ */
+function decimal(max) {
+  const f = getFormatter(DECIMAL_FORMATTERS, max);
+  return biasZero('negative', 'large', max, f);
+}
+
+module.exports = {
+  MAX_VALUE: LONG_MAX_VALUE,
+  age: age,
+  ageBiasOld: ageBiasOld,
+  bytes: bytes,
+  latency: latency,
+  latencyBiasSlow: latencyBiasSlow,
+  decimal: decimal,
+
+  // for testing
+  formatters: {
+    time: Object.freeze(TIME_FORMATTERS),
+    decimal: Object.freeze(DECIMAL_FORMATTERS),
+    binary: Object.freeze(BINARY_FORMATTERS)
+  }
+};

--- a/src/bucket_timer.js
+++ b/src/bucket_timer.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/** Timers that get updated based on the bucket for recorded values. */
+class BucketTimer {
+  /**
+   * Creates a timer object that manages a set of timers based on the bucket
+   * function supplied. Calling record will be mapped to the record on the appropriate timer.
+   *
+   * @param {registry} registry
+   *     Registry to use.
+   * @param {id} id
+   *     Identifier for the metric being registered.
+   * @param {function} bucketFunction
+   *     Function to map values to buckets. See {@link BucketFunctions} for more information.
+   */
+  constructor(registry, id, bucketFunction) {
+    this.registry = registry;
+    this.id = id;
+    this.bucketFunction = bucketFunction;
+  }
+
+  _timer(bucket) {
+    return this.registry.timer(this.id.withTag('bucket', bucket));
+  }
+
+  record(seconds, nanos) {
+    let totalNanos;
+    const ns = nanos || 0;
+
+    if (seconds instanceof Array) {
+      totalNanos = seconds[0] * 1e9 + (seconds[1] || 0);
+    } else {
+      totalNanos = seconds * 1e9 + ns;
+    }
+
+    this._timer(this.bucketFunction(totalNanos)).record(0, totalNanos);
+  }
+}
+
+module.exports = BucketTimer;

--- a/test/bucket_counter.test.js
+++ b/test/bucket_counter.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const chai = require('chai');
+const assert = chai.assert;
+const Registry = require('../src/registry');
+const BucketFunctions = require('../src/bucket_functions');
+const BucketCounter = require('../src/bucket_counter');
+
+describe('Bucket Counters', () => {
+  function filter(meters, name)  {
+    return meters.filter(m => m.id.name === name);
+  }
+
+  function sum(counters) {
+    return counters.reduce((sum, m) => sum + m.count, 0);
+  }
+
+  it('basic operations', () => {
+    const r = new Registry();
+    const c = new BucketCounter(r, r.newId('test'), BucketFunctions.latency(4, 's'));
+
+    c.record(3750 * 1e6);
+    let meters = filter(r.meters(), 'test');
+    assert.lengthOf(meters, 1);
+    assert.equal(sum(meters), 1);
+    assert.equal(meters[0].id.tags.get('bucket'), '4000ms');
+
+    c.record(4221 * 1e6);
+    meters = filter(r.meters(), 'test');
+    assert.lengthOf(meters, 2);
+    assert.equal(sum(meters), 2);
+
+    c.record(3700 * 1e6);
+    meters = filter(r.meters(), 'test');
+    assert.lengthOf(meters, 2);
+    assert.equal(sum(meters), 3);
+  });
+});

--- a/test/bucket_dist_summary.test.js
+++ b/test/bucket_dist_summary.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const chai = require('chai');
+const assert = chai.assert;
+const Registry = require('../src/registry');
+const BucketFunctions = require('../src/bucket_functions');
+const BucketDistributionSummary = require('../src/bucket_dist_summary');
+
+describe('Bucket Distribution Summary', () => {
+  function filter(meters, name)  {
+    return meters.filter(m => m.id.name === name);
+  }
+
+  function sum(distSummaries) {
+    return distSummaries.reduce((sum, m) => sum + m.count, 0);
+  }
+
+  it('basic operations', () => {
+    const r = new Registry();
+    const c = new BucketDistributionSummary(r, r.newId('test'), BucketFunctions.latency(4, 's'));
+
+    c.record(3750 * 1e6);
+    let meters = filter(r.meters(), 'test');
+    assert.lengthOf(meters, 1);
+    assert.equal(sum(meters), 1);
+    assert.equal(meters[0].id.tags.get('bucket'), '4000ms');
+
+    c.record(4221 * 1e6);
+    meters = filter(r.meters(), 'test');
+    assert.lengthOf(meters, 2);
+    assert.equal(sum(meters), 2);
+
+    c.record(3700 * 1e6);
+    meters = filter(r.meters(), 'test');
+    assert.lengthOf(meters, 2);
+    assert.equal(sum(meters), 3);
+  });
+});

--- a/test/bucket_functions.test.js
+++ b/test/bucket_functions.test.js
@@ -1,0 +1,237 @@
+'use strict';
+
+const chai = require('chai');
+const assert = chai.assert;
+const BucketFunctions = require('../src/bucket_functions');
+
+function secondsToNanos(s) {
+  return s * 1e9;
+}
+
+function millisToNanos(ms) {
+  return ms * 1e6;
+}
+
+function microsToNanos(us) {
+  return us * 1e3;
+}
+
+describe('Bucket functions', () => {
+  it('age 200us', () => {
+    const f = BucketFunctions.age(200, 'us');
+    assert.equal(f(microsToNanos(-1)), 'future');
+    assert.equal(f(microsToNanos(0)), '025us');
+    assert.equal(f(microsToNanos(1)), '025us');
+    assert.equal(f(microsToNanos(25)), '025us');
+    assert.equal(f(microsToNanos(26)), '050us');
+    assert.equal(f(microsToNanos(50)), '050us');
+    assert.equal(f(microsToNanos(51)), '100us');
+    assert.equal(f(microsToNanos(71)), '100us');
+    assert.equal(f(microsToNanos(101)), '200us');
+    assert.equal(f(microsToNanos(191)), '200us');
+    assert.equal(f(microsToNanos(200)), '200us');
+    assert.equal(f(microsToNanos(201)), 'old');
+  });
+
+  it('age 2ms', () => {
+    const f = BucketFunctions.age(2, 'ms');
+    assert.equal(f(microsToNanos(-1)), 'future');
+    assert.equal(f(microsToNanos(0)), '0250us');
+    assert.equal(f(microsToNanos(1)), '0250us');
+    assert.equal(f(microsToNanos(250)), '0250us');
+    assert.equal(f(microsToNanos(251)), '0500us');
+    assert.equal(f(microsToNanos(500)), '0500us');
+    assert.equal(f(microsToNanos(501)), '1000us');
+    assert.equal(f(microsToNanos(701)), '1000us');
+    assert.equal(f(microsToNanos(1001)), '2000us');
+    assert.equal(f(microsToNanos(1801)), '2000us');
+    assert.equal(f(microsToNanos(2000)), '2000us');
+    assert.equal(f(microsToNanos(2001)), 'old');
+  });
+
+  it('age 60s', () => {
+    const f = BucketFunctions.age(60, 's');
+    assert.equal(f(secondsToNanos(-1)), 'future');
+    assert.equal(f(secondsToNanos(0)), '07s');
+    assert.equal(f(secondsToNanos(1)), '07s');
+    assert.equal(f(secondsToNanos(6)), '07s');
+    assert.equal(f(secondsToNanos(8)), '15s');
+    assert.equal(f(secondsToNanos(10)), '15s');
+    assert.equal(f(secondsToNanos(20)), '30s');
+    assert.equal(f(secondsToNanos(30)), '30s');
+    assert.equal(f(secondsToNanos(31)), '60s');
+    assert.equal(f(secondsToNanos(42)), '60s');
+    assert.equal(f(secondsToNanos(60)), '60s');
+    assert.equal(f(secondsToNanos(61)), 'old');
+  });
+
+  it('age 60s bias old', () => {
+    const f = BucketFunctions.ageBiasOld(60, 's');
+    assert.equal(f(secondsToNanos(-1)), 'future');
+    assert.equal(f(secondsToNanos(0)), '30s');
+    assert.equal(f(secondsToNanos(1)), '30s');
+    assert.equal(f(secondsToNanos(6)), '30s');
+    assert.equal(f(secondsToNanos(8)), '30s');
+    assert.equal(f(secondsToNanos(10)), '30s');
+    assert.equal(f(secondsToNanos(20)), '30s');
+    assert.equal(f(secondsToNanos(30)), '30s');
+    assert.equal(f(secondsToNanos(31)), '45s');
+    assert.equal(f(secondsToNanos(42)), '45s');
+    assert.equal(f(secondsToNanos(48)), '52s');
+    assert.equal(f(secondsToNanos(59)), '60s');
+    assert.equal(f(secondsToNanos(60)), '60s');
+    assert.equal(f(secondsToNanos(61)), 'old');
+  });
+
+  it('bytes 1k', () => {
+    const f = BucketFunctions.bytes(1024);
+    assert.equal(f(-1), 'negative');
+    assert.equal(f(212), '0256_B');
+    assert.equal(f(512), '0512_B');
+    assert.equal(f(761), '1024_B');
+    assert.equal(f(2012), 'large');
+  });
+
+  it('bytes 20k', () => {
+    const f = BucketFunctions.bytes(20000);
+    assert.equal(f(-1), 'negative');
+    assert.equal(f(761), '02_KiB');
+    assert.equal(f(4567), '04_KiB');
+    assert.equal(f(15761), '19_KiB');
+    assert.equal(f(20001), 'large');
+  });
+
+  it('bytes 5M', () => {
+    const f = BucketFunctions.bytes(5 * 1024 * 1024);
+    assert.equal(f(-1), 'negative');
+    assert.equal(f(100), '0640_KiB');
+    assert.equal(f(5e5), '0640_KiB');
+    assert.equal(f(1e6), '1280_KiB');
+    assert.equal(f(2e6), '2560_KiB');
+    assert.equal(f(5e6), '5120_KiB');
+    assert.equal(f(6e6), 'large');
+  });
+
+  it('bytes max values', () => {
+    const MAX = BucketFunctions.MAX_VALUE;
+    const f = BucketFunctions.bytes(MAX);
+    assert.equal(f(-1), 'negative');
+    assert.equal(f(761), '1024_PiB');
+    assert.equal(f(MAX / 4), '2048_PiB');
+    assert.equal(f(MAX / 2), '4096_PiB');
+    assert.equal(f(MAX), '8192_PiB');
+  });
+
+  it('latency 100ms', () => {
+    const f = BucketFunctions.latency(100, 'ms');
+    assert.equal(f(millisToNanos(0)), '012ms');
+    assert.equal(f(millisToNanos(1)), '012ms');
+    assert.equal(f(millisToNanos(13)), '025ms');
+    assert.equal(f(millisToNanos(25)), '025ms');
+    assert.equal(f(millisToNanos(99)), '100ms');
+    assert.equal(f(millisToNanos(101)), 'slow');
+  });
+
+  it('latency 100ms bias slow', () => {
+    const f = BucketFunctions.latencyBiasSlow(100, 'ms');
+    assert.equal(f(millisToNanos(-1)), 'negative_latency');
+    assert.equal(f(millisToNanos(0)), '050ms');
+    assert.equal(f(millisToNanos(1)), '050ms');
+    assert.equal(f(millisToNanos(13)), '050ms');
+    assert.equal(f(millisToNanos(25)), '050ms');
+    assert.equal(f(millisToNanos(74)), '075ms');
+    assert.equal(f(millisToNanos(75)), '075ms');
+    assert.equal(f(millisToNanos(76)), '087ms');
+    assert.equal(f(millisToNanos(99)), '100ms');
+    assert.equal(f(millisToNanos(101)), 'slow');
+  });
+
+  it('latency 3s', () => {
+    const f = BucketFunctions.latency(3, 's');
+    assert.equal(f(millisToNanos(-1)), 'negative_latency');
+    assert.equal(f(millisToNanos(0)), '0375ms');
+    assert.equal(f(millisToNanos(25)), '0375ms');
+    assert.equal(f(millisToNanos(740)), '0750ms');
+    assert.equal(f(millisToNanos(1000)), '1500ms');
+    assert.equal(f(millisToNanos(1567)), '3000ms');
+    assert.equal(f(millisToNanos(3001)), 'slow');
+  });
+
+  it('latency 3s bias slow', () => {
+    const f = BucketFunctions.latencyBiasSlow(3, 's');
+    assert.equal(f(millisToNanos(-1)), 'negative_latency');
+    assert.equal(f(millisToNanos(0)), '1500ms');
+    assert.equal(f(millisToNanos(1000)), '1500ms');
+    assert.equal(f(millisToNanos(1740)), '2250ms');
+    assert.equal(f(millisToNanos(2240)), '2250ms');
+    assert.equal(f(millisToNanos(2540)), '2625ms');
+    assert.equal(f(millisToNanos(2625)), '2625ms');
+    assert.equal(f(millisToNanos(2800)), '3000ms');
+    assert.equal(f(millisToNanos(3000)), '3000ms');
+    assert.equal(f(millisToNanos(3001)), 'slow');
+  });
+
+  function checkLatencyRange(latencyFun) {
+    for (let fmt of BucketFunctions.formatters.time) {
+      const max = fmt.max;
+      const f = latencyFun(max, 'ns');
+      const keys = new Set();
+      const step = (max > 37) ? Math.floor(max / 37) : 1;
+      for (let j = 0; max - j > step; j += step) {
+        keys.add(f(j));
+      }
+      keys.add(f(max));
+      assert.equal(keys.size, 4);
+      assert.equal(f(-1), 'negative_latency');
+
+      // can't simply do + 1 due to loss of precision for doubles approaching LONG_MAX
+      assert.equal(f(max + max), 'slow');
+    }
+  }
+
+  it('latency range', () => {
+    checkLatencyRange(BucketFunctions.latency);
+  });
+
+  it('latency bias slow range', () => {
+    checkLatencyRange(BucketFunctions.latencyBiasSlow);
+  });
+
+  it('decimal 20k', () => {
+    const f = BucketFunctions.decimal(20000);
+    assert.equal(f(-1), 'negative');
+    assert.equal(f(761), '02_k');
+    assert.equal(f(4567), '05_k');
+    assert.equal(f(15761), '20_k');
+    assert.equal(f(20001), 'large');
+  });
+
+  it('decimal 5G', () => {
+    const f = BucketFunctions.decimal(5 * 1e9);
+    assert.equal(f(-1), 'negative');
+    assert.equal(f(761), '0625_M');
+    assert.equal(f(700 * 1e6), '1250_M');
+    assert.equal(f(2000 * 1e6), '2500_M');
+    assert.equal(f(4000 * 1e6), '5000_M');
+    assert.equal(f(6e9), 'large');
+  });
+
+  it('decimal 2M', () => {
+    const f = BucketFunctions.decimal(2 * 1e6);
+    assert.equal(f(-1), 'negative');
+    assert.equal(f(761), '0250_k');
+    assert.equal(f(400  * 1e3), '0500_k');
+    assert.equal(f(1000 * 1e3), '1000_k');
+    assert.equal(f(2 * 1e6), '2000_k');
+    assert.equal(f(2.1 * 1e6), 'large');
+  });
+
+  it('decimal max value', () => {
+    const f = BucketFunctions.decimal(BucketFunctions.MAX_VALUE);
+    assert.equal(f(-1), 'negative');
+    assert.equal(f(761), '1152_P');
+    assert.equal(f(BucketFunctions.MAX_VALUE / 4), '2305_P');
+    assert.equal(f(BucketFunctions.MAX_VALUE / 2), '4611_P');
+    assert.equal(f(BucketFunctions.MAX_VALUE), '9223_P');
+  });
+});

--- a/test/bucket_timer.test.js
+++ b/test/bucket_timer.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const chai = require('chai');
+const assert = chai.assert;
+const Registry = require('../src/registry');
+const BucketFunctions = require('../src/bucket_functions');
+const BucketTimer = require('../src/bucket_timer');
+
+describe('Bucket Timer', () => {
+  function filter(meters, name)  {
+    return meters.filter(m => m.id.name === name);
+  }
+
+  function sum(timers) {
+    return timers.reduce((sum, m) => sum + m.count, 0);
+  }
+
+  it('basic operations', () => {
+    const r = new Registry();
+    const c = new BucketTimer(r, r.newId('test'), BucketFunctions.latency(4, 's'));
+
+    c.record(3, 750 * 1e6);
+    let meters = filter(r.meters(), 'test');
+    assert.lengthOf(meters, 1);
+    assert.equal(sum(meters), 1);
+    assert.equal(meters[0].id.tags.get('bucket'), '4000ms');
+
+    c.record(4, 221 * 1e6);
+    meters = filter(r.meters(), 'test');
+    assert.lengthOf(meters, 2);
+    assert.equal(sum(meters), 2);
+
+    c.record([3, 700 * 1e6]);
+    meters = filter(r.meters(), 'test');
+    assert.lengthOf(meters, 2);
+    assert.equal(sum(meters), 3);
+  });
+});


### PR DESCRIPTION
* `BucketTimer`: A timer that manages a set of timers that get updated
based on the bucket function supplied.

* `BucketCounter`: A distribution summary that manages a set a counters
that will be updated based on the bucket function supplied.

* `BucketDistributionSummary`: A distribution summary that manages a set
of distribution summaries that will be updated based on the bucket
function supplied.

A set of `BucketFunctions` is supplied:

* `age`: a function that maps ages to a set of buckets creating more
buckets towards the fresher end of the range.

* `ageBiasOld`: a function that maps ages to a set of buckets creating more
buckets towards the older end of the range.

* `latency`: a function that maps latencies to a set of buckets
creating more buckets towards the faster end of the range.

* `latencyBiasSlow`: a function that maps latencies to a set of buckets
creating more buckets towards the slower end of the range.

* `bytes`: a function that maps size values to a set of buckets using
powers of 2.

* `decimal`: a function that maps size values to a set of buckets using
powers of 10.