### PR TITLE
Support for PolledMeters

### DIFF
--- a/src/bucket_counter.js
+++ b/src/bucket_counter.js
@@ -2,6 +2,10 @@
 
 /** Counters that get incremented based on the bucket for recorded values. */
 class BucketCounter {
+  static get(registry, id, bucketFunction) {
+    return new BucketCounter(registry, id, bucketFunction);
+  }
+
   /**
    * Creates a distribution summary object that manages a set of counters based on the bucket
    * function supplied. Calling record will increment the appropriate counter.

--- a/src/bucket_dist_summary.js
+++ b/src/bucket_dist_summary.js
@@ -2,6 +2,10 @@
 
 /** Distribution summaries that get updated based on the bucket for recorded values. */
 class BucketDistributionSummary {
+  static get(registry, id, bucketFunction) {
+    return new BucketDistributionSummary(registry, id, bucketFunction);
+  }
+
   /**
    * Creates a distribution summary object that manages a set of distribution summaries based on
    * the bucket function supplied. Calling record will be mapped to the record on the appropriate

--- a/src/bucket_timer.js
+++ b/src/bucket_timer.js
@@ -2,6 +2,10 @@
 
 /** Timers that get updated based on the bucket for recorded values. */
 class BucketTimer {
+  static get(registry, id, bucketFunction) {
+    return new BucketTimer(registry, id, bucketFunction);
+  }
+
   /**
    * Creates a timer object that manages a set of timers based on the bucket
    * function supplied. Calling record will be mapped to the record on the appropriate timer.

--- a/src/meter_id.js
+++ b/src/meter_id.js
@@ -71,6 +71,39 @@ class MeterId {
     }
     return this.withTag('statistic', stat);
   }
+
+  static validate(name, tags) {
+    let errors = [];
+    function validateKeyValue(k, v) {
+      if (!k) {
+        errors.push('One or more tag keys are missing');
+      }
+      if (!v) {
+        const keyForMsg = k || '<missing>';
+        errors.push(`Value missing for key=${keyForMsg}`);
+      }
+    }
+
+    if (!name) {
+      errors.push('name must be present');
+    }
+
+    if (tags) {
+      if (tags instanceof Map) {
+        for (let [k, v] of tags.entries()) {
+          validateKeyValue(k, v);
+        }
+      } else {
+        for (let key of Object.keys(tags)) {
+          validateKeyValue(key, tags[key]);
+        }
+      }
+    }
+
+    if (errors.length > 0) {
+      throw new Error('Invalid MeterId: ' + errors.join('\n\t'));
+    }
+  }
 }
 
 module.exports = MeterId;

--- a/src/percentile_buckets.js
+++ b/src/percentile_buckets.js
@@ -109,14 +109,6 @@ function percentiles(counts, pcts) {
     prevP = nextP;
     prevB = nextB;
   }
-
-  const nextP = 100.0;
-  while (pctIdx < pcts.length) {
-    const f = (pcts[pctIdx] - prevP) / (nextP - prevP);
-    results[pctIdx] = f * (LONG_MAX_VALUE - prevB) + prevB;
-    ++pctIdx;
-  }
-
   return results;
 }
 

--- a/src/percentile_dist_summary.js
+++ b/src/percentile_dist_summary.js
@@ -27,6 +27,10 @@ for (let i = 0; i < percentiles.length; ++i) {
  * greatly restrict the worst case overhead.</p>
  */
 class PercentileDistributionSummary {
+  static get(registry, id) {
+    return new PercentileDistributionSummary(registry, id);
+  }
+
   /**
    * Creates a distribution summary object that can be used for estimating percentiles.
    * <b>Percentile distribution summaries are expensive compared to basic distribution summaries

--- a/src/percentile_timer.js
+++ b/src/percentile_timer.js
@@ -30,6 +30,10 @@ for (let i = 0; i < percentiles.length; ++i) {
  * and restricting to this window reduces the worst case multiple from 276 to 58</p>
  */
 class PercentileTimer {
+  static get(registry, id) {
+    return new PercentileTimer(registry, id);
+  }
+
   /**
    * Creates a timer object that can be used for estimating percentiles. <b>Percentile timers
    * are expensive compared to basic timers from the registry.</b> Be diligent with ensuring

--- a/src/polled_meter.js
+++ b/src/polled_meter.js
@@ -1,0 +1,144 @@
+'use strict';
+
+class CounterState {
+  constructor(counter) {
+    this.counter = counter;
+    this.interval = undefined;
+    this.functions = [];
+    this.prevNumbers = [];
+  }
+
+  add(f) {
+    this.functions.push(f);
+    this.prevNumbers.push(f());
+  }
+
+  schedule(delay) {
+    if (!this.interval) {
+      this.interval = setInterval(CounterState.update, delay, this);
+    }
+  }
+
+  static update(self) {
+    // each function generates a value
+    // add each delta to the counter associated with us
+    for (let i = 0; i < self.functions.length; ++i) {
+      const f = self.functions[i];
+      const prev = self.prevNumbers[i];
+      const current = f();
+      if (current > prev) {
+        console.log(`Incrementing ${self.counter.id.key} by ${current - prev}`);
+        self.counter.add(current - prev);
+        self.prevNumbers[i] = current;
+      }
+    }
+  }
+}
+
+class ValueState {
+  constructor(gauge) {
+    this.gauge = gauge;
+    this.interval = undefined;
+    this.functions = [];
+  }
+
+  add(f) {
+    this.functions.push(f);
+  }
+
+  schedule(delay) {
+    if (!this.interval) {
+      this.interval = setInterval(ValueState.update, delay, this);
+    }
+  }
+
+  static update(self) {
+    // each function generates a value
+    // add all of them and set the value of the gauge to that result
+    let result = 0;
+    for (let f of self.functions) {
+      result += f();
+    }
+    console.log(`Setting gauge ${self.gauge.id.key} to ${result}`);
+    self.gauge.set(result);
+  }
+}
+
+class PolledMeter {
+  static using(registry) {
+    class Builder {
+      constructor(r) {
+        this.registry = r;
+      }
+
+      withId(id) {
+        this.id = id;
+        return this;
+      }
+
+      withName(name) {
+        this.name = name;
+        return this;
+      }
+
+      withTags(tags) {
+        this.tags = tags;
+        return this;
+      }
+
+      monitorValue(fun) {
+        let id;
+        const r = this.registry;
+        if (this.id) {
+          id = this.id;
+        } else {
+          id = r.newId(this.name, this.tags);
+        }
+        const gauge = r.gauge(id);
+        const state = r.state;
+        let c = state.get(id.key);
+        if (!c) {
+          c = new ValueState(gauge);
+          state.set(id.key, c);
+        } else {
+          if (c.constructor.name !== 'ValueState') {
+            registry.throwTypeError(id, c.constructor.name, 'ValueState', 'PolledMeter');
+          }
+        }
+        if (c.constructor.name === 'ValueState') {
+          c.add(fun);
+          c.schedule(r.config.gaugePollingFrequency);
+        }
+      }
+
+      monitorMonotonicNumber(fun) {
+        let id;
+        const r = this.registry;
+        if (this.id) {
+          id = this.id;
+        } else {
+          id = r.newId(this.name, this.tags);
+        }
+        const counter = r.counter(id);
+        const state = r.state;
+        let c = state.get(id.key);
+        if (!c) {
+          c = new CounterState(counter);
+          state.set(id.key, c);
+        } else {
+          if (c.constructor.name !== 'CounterState') {
+            registry.throwTypeError(id, c.constructor.name, 'ValueState', 'PolledMeter');
+          }
+        }
+        if (c.constructor.name === 'CounterState') {
+          c.add(fun);
+          c.schedule(r.config.gaugePollingFrequency);
+        }
+      }
+    }
+
+    return new Builder(registry);
+  }
+}
+
+module.exports = PolledMeter;

--- a/test/bucket_counter.test.js
+++ b/test/bucket_counter.test.js
@@ -17,7 +17,7 @@ describe('Bucket Counters', () => {
 
   it('basic operations', () => {
     const r = new Registry();
-    const c = new BucketCounter(r, r.newId('test'), BucketFunctions.latency(4, 's'));
+    const c = BucketCounter.get(r, r.newId('test'), BucketFunctions.latency(4, 's'));
 
     c.record(3750 * 1e6);
     let meters = filter(r.meters(), 'test');

--- a/test/bucket_dist_summary.test.js
+++ b/test/bucket_dist_summary.test.js
@@ -17,7 +17,7 @@ describe('Bucket Distribution Summary', () => {
 
   it('basic operations', () => {
     const r = new Registry();
-    const c = new BucketDistributionSummary(r, r.newId('test'), BucketFunctions.latency(4, 's'));
+    const c = BucketDistributionSummary.get(r, r.newId('test'), BucketFunctions.latency(4, 's'));
 
     c.record(3750 * 1e6);
     let meters = filter(r.meters(), 'test');

--- a/test/bucket_timer.test.js
+++ b/test/bucket_timer.test.js
@@ -17,7 +17,7 @@ describe('Bucket Timer', () => {
 
   it('basic operations', () => {
     const r = new Registry();
-    const c = new BucketTimer(r, r.newId('test'), BucketFunctions.latency(4, 's'));
+    const c = BucketTimer.get(r, r.newId('test'), BucketFunctions.latency(4, 's'));
 
     c.record(3, 750 * 1e6);
     let meters = filter(r.meters(), 'test');

--- a/test/meter_id.test.js
+++ b/test/meter_id.test.js
@@ -54,4 +54,16 @@ describe('MeterIds', () => {
     assert.equal(id.withDefaultStat('counter').tags.get('statistic'), 'percentile');
   });
 
+  it('should validate metrics', () => {
+    assert.throws(() => MeterId.validate(undefined, {fo: 'v'}),
+      /name must be present/);
+    assert.throws(() => MeterId.validate('', {fo: 'v'}),
+      /name must be present/);
+    assert.throws(() => MeterId.validate('name', new Map([['', 'value']])),
+      /keys are missing/);
+    assert.throws(() => MeterId.validate('name', {'': 'value'}),
+      /keys are missing/);
+    assert.throws(() => MeterId.validate('name', {'nf.missing': ''}),
+      /Value missing for key=nf.missing/);
+  });
 });

--- a/test/percentile_dist_summary.test.js
+++ b/test/percentile_dist_summary.test.js
@@ -24,7 +24,7 @@ describe('Percentile Distribution Summaries', () => {
 
   it('constructor', () => {
     const r = new Registry();
-    const ds = new PercentileDistributionSummary(r, r.newId('p'));
+    const ds = PercentileDistributionSummary.get(r, r.newId('p'));
     checkPercentiles(ds, 0);
   });
 

--- a/test/percentile_timer.test.js
+++ b/test/percentile_timer.test.js
@@ -74,7 +74,7 @@ describe('Percentile Timers', () => {
     const expectedSum = N * (N - 1) / 2;
 
     const r = new Registry();
-    const timer = new PercentileTimer(r, r.newId('name'));
+    const timer = PercentileTimer.get(r, r.newId('name'));
     for (let i = 0; i < N; ++i) {
       timer.record([0, millisToNanos(i)]);
     }

--- a/test/polled_meter.test.js
+++ b/test/polled_meter.test.js
@@ -1,0 +1,124 @@
+'use strict';
+
+const chai = require('chai');
+const assert = chai.assert;
+const PolledMeter = require('../src/polled_meter');
+const Registry = require('../src/registry');
+
+describe('PolledMeter', () => {
+  it('monitorValue using name/tags', (done) => {
+    const r = new Registry({gaugePollingFrequency: 1, strictMode: true});
+    let i = 1;
+    PolledMeter.using(r).withName('polledMeter').withTags(
+      {foo: 'bar'}).monitorValue(() => i + 1);
+
+    setTimeout(() => {
+      const ms = r.meters();
+      assert.lengthOf(ms, 1);
+      assert.equal(ms[0].get(), 2);
+      r.stop();
+      done();
+    }, 2);
+  });
+
+  it('monitorValue using id', (done) => {
+    const r = new Registry({gaugePollingFrequency: 1, strictMode: true});
+    const id = r.newId('foo');
+    let x = 1;
+    PolledMeter.using(r).withId(id).monitorValue(() => x);
+    x = 42;
+
+    setTimeout(() => {
+      const ms = r.meters();
+      assert.lengthOf(ms, 1);
+      assert.equal(ms[0].get(), 42);
+      r.stop();
+      done();
+    }, 2);
+  });
+
+  it('monitorValue using multiple functions', (done) => {
+    const r = new Registry({gaugePollingFrequency: 1, strictMode: true});
+    const id = r.newId('foo');
+    let x = 1;
+    PolledMeter.using(r).withId(id).monitorValue(() => x);
+    PolledMeter.using(r).withId(id).monitorValue(() => x + 1);
+    x = 42;
+
+    setTimeout(() => {
+      const ms = r.meters();
+      assert.lengthOf(ms, 1);
+      assert.equal(ms[0].get(), 42 + 43);
+      r.stop();
+      done();
+    }, 2);
+  });
+
+  it('monotonic counters using name/tags', (done) => {
+    const r = new Registry({gaugePollingFrequency: 1, strictMode: true});
+
+    let x = 100;
+    PolledMeter.using(r).withName('foo').withTags({k:'v'}).monitorMonotonicNumber(() => x);
+
+    let y = 200;
+    PolledMeter.using(r).withName('foo').withTags({k:'v'}).monitorMonotonicNumber(() => y);
+
+    x = 142;
+    y = 201;
+
+    setTimeout(() => {
+      const ms = r.meters();
+      assert.lengthOf(ms, 1);
+      assert.equal(ms[0].count, 43);
+      r.stop();
+      done();
+    }, 2);
+  });
+
+  it('throws when mixing polled meters', () => {
+    const r = new Registry({gaugePollingFrequency: 1, strictMode: true});
+    const id = r.newId('foo');
+
+    let x = 100;
+    PolledMeter.using(r).withId(id).monitorMonotonicNumber(() => x);
+
+    assert.throws( () =>
+      PolledMeter.using(r).withId(id).monitorValue(() => x),
+      /Expecting a different type/);
+
+    const id2 = id.withTag('k', 'v');
+    PolledMeter.using(r).withId(id2).monitorValue(() => x);
+    assert.throws( () =>
+        PolledMeter.using(r).withId(id2).monitorMonotonicNumber(() => x),
+      /Expecting a different type/);
+
+    r.stop();
+  });
+
+  it('just logs errors when mixing polled meters (non-strict)', () => {
+    const r = new Registry({gaugePollingFrequency: 1, strictMode: false});
+
+    let errorCount = 0;
+    r.logger.error = (msg) => {
+      console.log(`INFO: ${msg}`);
+      errorCount++;
+    };
+
+    const id = r.newId('foo');
+    let x = 100;
+    PolledMeter.using(r).withId(id).monitorMonotonicNumber(() => x);
+    assert.equal(errorCount, 0);
+
+    PolledMeter.using(r).withId(id).monitorValue(() => x);
+    assert.equal(errorCount, 2);
+
+    const id2 = id.withTag('k', 'v');
+    PolledMeter.using(r).withId(id2).monitorValue(() => x);
+    assert.equal(errorCount, 2);
+
+    PolledMeter.using(r).withId(id2).monitorMonotonicNumber(() => x);
+    assert.equal(errorCount, 4);
+
+    r.stop();
+  });
+});

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -8,6 +8,7 @@ const MeterId = require('../src/meter_id');
 
 function newRegistry() {
   const c = {
+    strictMode: true,
     commonTags: {
       'nf.node': 'i-12345',
       'nf.cluster': 'app-main',


### PR DESCRIPTION
* Adds `monitorValue` to generate dynamic values for gauges

* Adds `monitorMonotonicNumer` to generate counter increments based on
monotonic values

To support this we also add a `strictMode` to the config to help
users catch errors during development by throwing when invalid
operations are attempted such as creating metrics with no names, or
empty keys/values as tags.