### PR TITLE
Support IntervalCounter

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ class Server {
   }
   
   handle(request) {
-    const start = process.hrtime();
+    const start = this.registry.hrtime();
     
     // do some work based on request and obtain a response
     const res = new Response(200, 64);
@@ -57,7 +57,7 @@ class Server {
     const counterId = this.requestCountId.withTags({country: request.country, 
         status: res.status});
     this.registry.counter(counterId).increment();
-    this.requestLatency.record(process.hrtime(start));
+    this.requestLatency.record(this.registry.hrtime(start));
     this.responseSize.record(res.size);
     return res;
   }

--- a/src/http.js
+++ b/src/http.js
@@ -28,8 +28,8 @@ class HttpClient {
       protocol: url.protocol
     };
 
-    const start = process.hrtime();
-    const self = this;
+    const registry = this.registry;
+    const start = registry.hrtime();
     const request = http.request(options, (res) => {
       let data = '';
       res.setEncoding('utf8');
@@ -39,7 +39,7 @@ class HttpClient {
       res.on('end', () => {
         const statusFamily = `${Math.floor(res.statusCode / 100)}xx`;
         const timerId = baseId.withTags({statusCode: res.statusCode, status: statusFamily});
-        self.registry.timer(timerId).record(process.hrtime(start));
+        registry.timer(timerId).record(registry.hrtime(start));
 
         if (statusFamily !== '2xx') {
           log.error(`POST to ${endpoint}: ${res.statusCode} - ${data}`);
@@ -57,14 +57,14 @@ class HttpClient {
         // the error message
         log.error(`problem with request: ${e.message}`);
       }
-      self.registry.timer(baseId, {statusCode: error, status: error})
-        .record(process.hrtime(start));
+      registry.timer(baseId, {statusCode: error, status: error})
+        .record(registry.hrtime(start));
     });
 
     const timeout = this.registry.config.timeout || 1000;
     request.setTimeout(timeout, () => {
       request.abort();
-      const elapsed = process.hrtime(start);
+      const elapsed = registry.hrtime(start);
       const seconds = elapsed[0] + elapsed[1] / 1e9;
       log.error(`Timeout POSTing to ${endpoint} after ${seconds.toFixed(2)}s`);
     });

--- a/src/interval_counter.js
+++ b/src/interval_counter.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const PolledMeter = require('./polled_meter');
+const NopRegistry = require('./nop_registry');
+
+/**
+ * A counter that also keeps track of the time since last update.
+ */
+class IntervalCounter {
+  // Use IntervalCounter.get() - do not use this constructor directly
+  constructor(registry, id) {
+    this.registry = registry;
+    this.counter = registry.counter(id.withStat('count'));
+    this.lastUpdated = undefined;
+    PolledMeter.using(registry)
+      .withId(id.withStat('duration')).monitorValue(() => this.secondsSinceLastUpdate);
+  }
+
+  add(delta) {
+    this.lastUpdated = this.registry.hrtime();
+    this.counter.add(delta);
+  }
+
+  get count() {
+    return this.counter.count;
+  }
+
+  get secondsSinceLastUpdate() {
+    const elapsed = this.registry.hrtime(this.lastUpdated);
+    return elapsed[0] + elapsed[1] / 1e9;
+  }
+
+  /**
+   * Creates a counter that also keeps track of the time since last updated.
+   *
+   * @param {Registry} registry
+   *     Registry to use.
+   * @param {MeterId} id
+   *     Identifier for the metric being registered.
+   * @return {IntervalCounter}
+   *     Timer instance.
+   */
+  static get(registry, id) {
+    const state = registry.state;
+    let ic = state.get(id.key);
+    if (ic) {
+      if (ic.constructor.name === 'IntervalCounter') {
+        return ic;
+      }
+      // throws if strictMode
+      registry.throwTypeError(id, ic.constructor.name, 'IntervalCounter', 'IntervalCounter');
+      return new IntervalCounter(new NopRegistry(), id); // dummy, since the registry will not send any metrics
+    }
+
+    // make sure we don't attempt to register an id which is used for something else
+    const prevMeter = registry.metersMap.get(id.key);
+    if (prevMeter) {
+      // throws if strictMode
+      registry.throwTypeError(id, prevMeter.constructor.name, 'IntervalCounter', 'IntervalCounter');
+      return new IntervalCounter(new NopRegistry(), id);
+    }
+    ic = new IntervalCounter(registry, id);
+    state.set(id.key, ic);
+    return ic;
+  }
+}
+
+module.exports = IntervalCounter;

--- a/src/nop_registry.js
+++ b/src/nop_registry.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const Counter = require('./counter');
+const Gauge = require('./gauge');
+
+class NopRegistry {
+  constructor() {
+    this.state = new Map();
+    this.config = {
+      gaugePollingFrequency: 10000
+    };
+  }
+
+  counter(id) {
+    return new Counter(id);
+  }
+  gauge(id) {
+    return new Gauge(id);
+  }
+
+  schedulePeriodically() {
+    console.log(JSON.stringify(arguments));
+  }
+
+  hrtime(time) {
+    return [0, 0];
+  }
+}
+
+module.exports = NopRegistry;

--- a/src/polled_meter.js
+++ b/src/polled_meter.js
@@ -13,9 +13,10 @@ class CounterState {
     this.prevNumbers.push(f());
   }
 
-  schedule(delay) {
+  schedule(registry) {
     if (!this.interval) {
-      this.interval = setInterval(CounterState.update, delay, this);
+      const delay = registry.config.gaugePollingFrequency;
+      this.interval = registry.schedulePeriodically(CounterState.update, delay, this);
     }
   }
 
@@ -45,9 +46,10 @@ class ValueState {
     this.functions.push(f);
   }
 
-  schedule(delay) {
+  schedule(registry) {
     if (!this.interval) {
-      this.interval = setInterval(ValueState.update, delay, this);
+      const delay = registry.config.gaugePollingFrequency;
+      this.interval = registry.schedulePeriodically(ValueState.update, delay, this);
     }
   }
 
@@ -105,7 +107,7 @@ class PolledMeter {
         }
         if (c.constructor.name === 'ValueState') {
           c.add(fun);
-          c.schedule(r.config.gaugePollingFrequency);
+          c.schedule(r);
         }
       }
 
@@ -130,7 +132,7 @@ class PolledMeter {
         }
         if (c.constructor.name === 'CounterState') {
           c.add(fun);
-          c.schedule(r.config.gaugePollingFrequency);
+          c.schedule(r);
         }
       }
     }

--- a/src/registry.js
+++ b/src/registry.js
@@ -170,8 +170,16 @@ class AtlasRegistry {
   }
 
   throwTypeError(id, registeredType, newType, requestedMeter) {
+    let article;
+    const firstLetter = newType.substr(0, 1).toLowerCase();
+    if (['a', 'e', 'i', 'o', 'u'].indexOf(firstLetter) >= 0) {
+      article = 'an';
+    } else {
+      article = 'a';
+    }
+
     const msg = `When creating an instance of ${requestedMeter} with id=${id.key}, ` +
-      `found a ${registeredType} but was expecting a ${newType}`;
+      `found a ${registeredType} but was expecting ${article} ${newType}`;
     if (this.config.strictMode) {
       throw new Error(msg);
     } else {
@@ -299,6 +307,26 @@ class AtlasRegistry {
       MeterId.validate(name, tags);
     }
     return new MeterId(name, tags);
+  }
+
+  /**
+   * Schedule a task periodically.  See setInterval()
+   *
+   * @param {*} args - Arguments delegated to setInterval
+   * @returns {number}
+   */
+  schedulePeriodically(args) {
+    return setInterval.apply(this, arguments);
+  }
+
+  /**
+   * High resolution timer.
+   *
+   * @param {number[]} [time] - The result of a previous call to registry.hrtime()
+   * @return {number[]} - [seconds, nanoseconds]
+   */
+  hrtime(time) {
+    return process.hrtime(time);
   }
 }
 


### PR DESCRIPTION
A counter that keeps track of its last update

This adds a couple of methods to the registry to facilitate testing. In
particular we add: `hrtime` so we can mock the clock, and
`schedulePeriodically` so we can ignore calls to `setInterval` done when
using dummy meters (those that are returned when an existing id in the
registry is of a different type)