### PR TITLE
API updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ class Server {
   constructor(registry) {
     this.registry = registry;
     // create a base Id, to which we'll add some dynamic tags later
-    this.requestCountId = registry.newId('server.requestCount', {version: 'v1'});
+    this.requestCountId = registry.createId('server.requestCount', {version: 'v1'});
     this.requestLatency = registry.timer('server.requestLatency');
     this.responseSize = registry.distributionSummary('server.responseSizes');
   }

--- a/src/counter.js
+++ b/src/counter.js
@@ -1,25 +1,50 @@
 'use strict';
 
+/**
+ * Measures the rate of change based on calls to increment.
+ */
 class Counter {
+  /**
+   * Create a new instance with a given id.
+   *
+   * @param {MeterId} id identifier for this meter.
+   */
   constructor(id) {
     this.id = id;
     this.count = 0;
   }
 
-  increment(delta) {
-    if (delta) {
-      if (delta > 0) {
-        this.count += delta;
+  /**
+   * Update the counter by amount.
+   * @param {number} [amount=1] amount to add to the counter.
+   * @return {undefined}
+   */
+  increment(amount) {
+    if (amount !== undefined) {
+      if (amount > 0) {
+        this.count += amount;
       }
     } else {
       ++this.count;
     }
   }
 
-  add(delta) {
-    this.increment(delta);
+  /**
+   * Update the counter by amount.
+   * @param {number} [amount=1] amount to add to the counter.
+   * @return {undefined}
+   */
+  add(amount) {
+    this.increment(amount);
   }
 
+
+  /**
+   * Get the measurements for this meter.
+   *
+   * @return {Object[]} Either an empty array or an array with
+   *                    one entry representing the count.
+   */
   measure() {
     const c = this.count;
 

--- a/src/dist_summary.js
+++ b/src/dist_summary.js
@@ -1,23 +1,63 @@
 'use strict';
 
+/**
+ * Track the sample distribution of events. An example would be the response sizes for requests
+ * hitting and http server.
+ *
+ *  This meter will report four measurements to atlas:
+ * <ul>
+ *   <li><b>count:</b> counter incremented each time record is called</li>
+ *   <li><b>totalAmount:</b> counter incremented by the recorded amount</li>
+ *   <li><b>totalOfSquares:</b> counter incremented by the recorded amount squared</li>
+ *   <li><b>max:</b> maximum recorded amount</li>
+ * </ul>
+ *
+ * <p>Having an explicit totalAmount and count on the backend
+ * can be used to calculate an accurate average for an arbitrary grouping. The
+ * totalOfSquares is used for computing a standard deviation.</p>
+ *
+ * <p>Note that the count and totalAmount will report
+ * the values since the last measurement was taken rather than the total for the
+ * life of the process.</p>
+ */
 class DistributionSummary {
+  /**
+   * Create a new instance with a given id.
+   *
+   * @param {MeterId} id identifier for this meter.
+   */
   constructor(id) {
     this.id = id;
-    this.reset();
+    this._reset();
   }
 
-  reset() {
+  /**
+   * Reset our measurements.
+   *
+   * @return {undefined}
+   * @private
+   */
+  _reset() {
     this.count = 0;
     this.totalAmount = 0;
     this.totalOfSquares = 0.0;
     this.max = 0;
   }
 
+  /**
+   * Updates the statistics kept by the summary with the specified amount.
+   *
+   * @param {number} amount
+   *     Amount for an event being measured. For example, if the size in bytes of responses
+   *     from a server. If the amount is less than 0 the value will be dropped.
+   *
+   * @return {undefined}
+   */
   record(amount) {
     if (amount >= 0) {
       this.count++;
       this.totalAmount += amount;
-      this.totalOfSquares += 1.0 * amount * amount;
+      this.totalOfSquares += amount * amount;
 
       if (this.count === 1) {
         this.max = amount;
@@ -27,13 +67,20 @@ class DistributionSummary {
     }
   }
 
+  /**
+   * Get the measurements for this summary.
+   *
+   * @return {Object[]} Either an empty array or an array with
+   *                    four entries representing the
+   *                    count, totalAmount, totalOfSquares, and max.
+   */
   measure() {
     const c = this.count;
     const t = this.totalAmount;
     const t2 = this.totalOfSquares;
     const m = this.max;
 
-    this.reset();
+    this._reset();
 
     if (c > 0) {
       return [

--- a/src/gauge.js
+++ b/src/gauge.js
@@ -1,19 +1,45 @@
 'use strict';
 
+/**
+ * A meter with a single value that can only be sampled at a point in time. A typical example is
+ * a queue size.
+ */
 class Gauge {
+  /**
+   * Create a new instance with a given id.
+   *
+   * @param {MeterId} id identifier for this meter.
+   */
   constructor(id) {
     this.id = id;
     this.value_ = NaN;
   }
 
+  /**
+   * Set the current gauge value to the specified number.
+   *
+   * @param {number} value Number to be used when reporting the value to atlas.
+   * @return {undefined}
+   */
   set(value) {
     this.value_ = value;
   }
 
+  /**
+   * Get the current value.
+   * @return {number} The current value for this gauge.
+   */
   get() {
     return this.value_;
   }
 
+  /**
+   * Get the measurements for this gauge.
+   *
+   * @return {Object[]} Either an empty array or an array with
+   *                    one entry representing the
+   *                    last value set.
+   */
   measure() {
     const v = this.value_;
     this.value_ = NaN;

--- a/src/http.js
+++ b/src/http.js
@@ -15,7 +15,7 @@ class HttpClient {
     const log = this.registry.logger;
     const url = URL.parse(endpoint);
 
-    const baseId = this.registry.newId('http.req.complete',
+    const baseId = this.registry.createId('http.req.complete',
       {method: 'POST', mode: 'http-client', client: 'spectator-js'});
     const jsonStr = JSON.stringify(payload);
     headers['Content-length'] = Buffer.byteLength(jsonStr);

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,25 @@
 'use strict';
 
 const AtlasRegistry = require('./registry');
-
-function newRegistry(config) {
-  return new AtlasRegistry(config);
-}
+const PolledMeter = require('./polled_meter');
+const PercentileTimer = require('./percentile_timer');
+const PercentileDistributionSummary = require('./percentile_dist_summary');
+const BucketFunctions = require('./bucket_functions');
+const BucketCounter = require('./bucket_counter');
+const BucketDistributionSummary = require('./bucket_dist_summary');
+const BucketTimer = require('./bucket_timer');
+const IntervalCounter = require('./interval_counter');
+const LongTaskTimer = require('./long_task_timer');
 
 module.exports = {
-  newRegistry: newRegistry
+  Registry: AtlasRegistry,
+  PolledMeter: PolledMeter,
+  PercentileTimer: PercentileTimer,
+  PercentileDistributionSummary: PercentileDistributionSummary,
+  BucketFunctions: BucketFunctions,
+  BucketCounter: BucketCounter,
+  BucketDistributionSummary: BucketDistributionSummary,
+  BucketTimer: BucketTimer,
+  IntervalCounter: IntervalCounter,
+  LongTaskTimer: LongTaskTimer
 };

--- a/src/nop_registry.js
+++ b/src/nop_registry.js
@@ -22,7 +22,7 @@ class NopRegistry {
     console.log(JSON.stringify(arguments));
   }
 
-  hrtime(time) {
+  hrtime() {
     return [0, 0];
   }
 }

--- a/src/percentile_dist_summary.js
+++ b/src/percentile_dist_summary.js
@@ -96,7 +96,7 @@ class PercentileDistributionSummary {
         if (this.id) {
           id = this.id;
         } else {
-          id = this.registry.newId(this.name, this.tags);
+          id = this.registry.createId(this.name, this.tags);
         }
         return new PercentileDistributionSummary(this.registry, id, this.min, this.max);
       }

--- a/src/percentile_timer.js
+++ b/src/percentile_timer.js
@@ -93,7 +93,7 @@ class PercentileTimer {
         if (this.id) {
           id = this.id;
         } else {
-          id = this.registry.newId(this.name, this.tags);
+          id = this.registry.createId(this.name, this.tags);
         }
         return new PercentileTimer(this.registry, id, this.min, this.max);
       }

--- a/src/polled_meter.js
+++ b/src/polled_meter.js
@@ -92,7 +92,7 @@ class PolledMeter {
         if (this.id) {
           id = this.id;
         } else {
-          id = r.newId(this.name, this.tags);
+          id = r.createId(this.name, this.tags);
         }
         const gauge = r.gauge(id);
         const state = r.state;
@@ -117,7 +117,7 @@ class PolledMeter {
         if (this.id) {
           id = this.id;
         } else {
-          id = r.newId(this.name, this.tags);
+          id = r.createId(this.name, this.tags);
         }
         const counter = r.counter(id);
         const state = r.state;

--- a/src/registry.js
+++ b/src/registry.js
@@ -6,15 +6,19 @@ const Gauge = require('./gauge');
 const Timer = require('./timer');
 const DistributionSummary = require('./dist_summary');
 const HttpClient = require('./http');
+const process = require("./nop_registry");
+const process = require("./nop_registry");
 
+// The default logger. In general users should provide their
+// own logger implementation that integrates with their setup
 class SimpleLogger {
-  info() {
-    arguments[0] = 'INFO: ' + arguments[0];
+  debug() {
+    arguments[0] = 'DEBUG: ' + arguments[0];
     console.log.apply(console, arguments);
   }
 
-  debug() {
-    arguments[0] = 'DEBUG: ' + arguments[0];
+  info() {
+    arguments[0] = 'INFO: ' + arguments[0];
     console.log.apply(console, arguments);
   }
 
@@ -28,7 +32,6 @@ class SimpleLogger {
 class Publisher {
   constructor(registry) {
     this.registry = registry;
-    this.frequency = registry.config.frequency || 5;
     this.http = new HttpClient(registry);
   }
 
@@ -119,7 +122,30 @@ class Publisher {
 
 }
 
+/**
+ * Registry to manage a set of meters.
+ */
 class AtlasRegistry {
+  /**
+   * Creates a new AtlasRegistry with a given config. A config is an object that
+   * controls the behavior of this registry:
+   *
+   *   * uri: URI to use for sending measurements. If not present this registry will not start.
+   *
+   *   * commonTags: Tags to add to all measurements
+   *
+   *   * logger: The logger to use for this registry. Should provide: debug, info, error
+   *             methods that take a string.
+   *
+   *   * strictMode: A boolean that specifies whether extra validations should be performed, and whether to
+   *                 throw or just log errors.
+   *
+   *   * gaugePollingFrequency: milliseconds at which to poll meters. Default 10000.
+   *
+   *   * frequency: milliseconds at which we send updates to our aggregator. Default 5000.
+   *
+   *   @param {Object} config Configuration settings. See above.
+   */
   constructor(config) {
     this.config = config || {};
     if (!this.config.gaugePollingFrequency) {
@@ -150,12 +176,23 @@ class AtlasRegistry {
     }
   }
 
-  hasCorrectType(id, registeredMeter, newMeter) {
+  /**
+   * Checks whether the newMeter and registeredMeter have the same type.
+   * If the registered * was configured to use strictMode then this method
+   * will throw if the types are not compatible.
+   *
+   * @param {Object} registeredMeter the previously registered meter
+   * @param {Object} newMeter meter we are currently trying to register
+   * @return {boolean} whether the types are compatible
+   * @private
+   */
+  _hasCorrectType(registeredMeter, newMeter) {
     const actualClass = registeredMeter.constructor.name;
     const expectedClass = newMeter.constructor.name;
     let msg;
     if (actualClass !== expectedClass) {
-      msg = `Expecting a different type when creating a ${expectedClass} for id=${id.key}. ` +
+      const idStr = registeredMeter.id.key;
+      msg = `Expecting a different type when creating a ${expectedClass} for id=${idStr}. ` +
         `Found ${actualClass} already registered with the same id when ` +
         `${expectedClass} was expected`;
       if (this.config.strictMode) {
@@ -169,6 +206,17 @@ class AtlasRegistry {
     return true;
   }
 
+  /**
+   * Throws or logs an error due to an incompatible meter trying to be registered. If running
+   * under strictMode this method will throw an Error, otherwise it will log an error
+   * message using the registry's logger.
+   *
+   * @param {MeterId} id Meter id of the meter trying to be registered
+   * @param {string} registeredType type already in the registry
+   * @param {string} newType attempted type to be registered
+   * @param {Object} requestedMeter the meter that caused the error
+   * @return {undefined}
+   */
   throwTypeError(id, registeredType, newType, requestedMeter) {
     let article;
     const firstLetter = newType.substr(0, 1).toLowerCase();
@@ -187,7 +235,13 @@ class AtlasRegistry {
     }
   }
 
-  shouldStart() {
+  /**
+   * Determine whether the start method of this registry should do work.
+   *
+   * @return {boolean} Value indicating whether start should proceed, or just do nothing.
+   * @private
+   */
+  _shouldStart() {
     const log = this.logger;
 
     if (this.started) {
@@ -206,29 +260,41 @@ class AtlasRegistry {
     return true;
   }
 
+  /**
+   * Start collecting and sending metrics to an atlas-aggregator service.
+   * @return {undefined}
+   */
   start() {
     const c = this.config;
 
-    if (!this.shouldStart()) {
+    if (!this._shouldStart()) {
       return;
     }
 
     this.logger.info('Starting spectator registry');
     this.started = true;
-    this.startId = setInterval(this.publish, c.frequency || 5000, this);
+    this.startId = setInterval(AtlasRegistry._publish, c.frequency || 5000, this);
   }
 
-  newMeter(id, Clazz) {
+  /**
+   * Adds a new meter to this registry if needed, otherwise it returns the existing meter.
+   *
+   * @param {MeterId} id of the requested meter
+   * @param {*} Class class of the requested meter. It assumes it has a constructor that takes an id.
+   * @return {*} A meter of class `Class`
+   * @private
+   */
+  _newMeter(id, Class) {
     const key = id.key;
-    const meter = new Clazz(id);
+    const meter = new Class(id);
 
     const m = this.metersMap.get(key);
     if (m) {
-      if (this.hasCorrectType(id, m, meter)) {
+      if (this._hasCorrectType(m, meter)) {
         return m;
       }
       // wrong type registered, return a dummy meter not associated
-      // with the registry (if running under strictMode hasCorrectType throws)
+      // with the registry (if running under strictMode _hasCorrectType throws)
       return meter;
     }
 
@@ -236,38 +302,83 @@ class AtlasRegistry {
     return meter;
   }
 
+  /**
+   * Gets an id from a base id or name and optional additonal tags.
+   *
+   * @param {*} nameOrId either a string or a base id
+   * @param {*} tags an object or Map with tags
+   * @return {MeterId} A new MeterId
+   * @private
+   */
   _getId(nameOrId, tags) {
     if (nameOrId.constructor.name === 'MeterId') {
       return nameOrId.withTags(tags);
     }
-    return this.newId(nameOrId, tags);
+    return this.createId(nameOrId, tags);
   }
 
+  /**
+   * Measures the rate of some activity. A counter is for continuously incrementing sources like
+   * the number of requests that are coming into a server.
+   *
+   * @param {*} nameOrId either a string with a name, or a base id
+   * @param {*} tags an object or Map with tags
+   * @return {Counter} A counter that is registered with this registry.
+   */
   counter(nameOrId, tags) {
     const meterId = this._getId(nameOrId, tags);
-    return this.newMeter(meterId, Counter);
+    return this._newMeter(meterId, Counter);
   }
 
-  gauge(nameOrId, tags) {
-    const meterId = this._getId(nameOrId, tags);
-    return this.newMeter(meterId, Gauge);
-  }
-
-  timer(nameOrId, tags) {
-    const meterId = this._getId(nameOrId, tags);
-    return this.newMeter(meterId, Timer);
-  }
-
+  /**
+   * Measures the rate and variation in amount for some activity. For example, it could be used to
+   * get insight into the variation in response sizes for requests to a server.
+   *
+   * @param {*} nameOrId either a string with a name, or a base id
+   * @param {*} tags an object or Map with tags
+   * @return {DistributionSummary} A distribution summary that is registered with this registry.
+   */
   distributionSummary(nameOrId, tags) {
     const meterId = this._getId(nameOrId, tags);
-    return this.newMeter(meterId, DistributionSummary);
+    return this._newMeter(meterId, DistributionSummary);
   }
 
-  publish(self) {
+  /**
+   * Represents a value sampled from another source. For example, the size of queue. The caller
+   * is responsible for sampling the value regularly and calling its set() method.
+   * If you do not want to worry about the sampling, then use {@link PolledMeter}
+   * instead.
+   *
+   * @param {*} nameOrId either a string with a name, or a base id
+   * @param {*} tags an object or Map with tags
+   * @return {Gauge} A gauge that is registered with this registry.
+   */
+  gauge(nameOrId, tags) {
+    const meterId = this._getId(nameOrId, tags);
+    return this._newMeter(meterId, Gauge);
+  }
+
+  /**
+   * Measures the rate and time taken for short running tasks.
+   *
+   * @param {*} nameOrId either a string with a name, or a base id
+   * @param {*} tags an object or Map with tags
+   * @return {Timer} A timer that is registered with this registry.
+   */
+  timer(nameOrId, tags) {
+    const meterId = this._getId(nameOrId, tags);
+    return this._newMeter(meterId, Timer);
+  }
+
+
+  // publish metrics now
+  static _publish(self) {
     self.publisher.sendMetricsNow();
   }
 
-  _clearStateUpdates() {
+  // removes the previous state
+  // ensuring that any registered intervals are cleared
+  _clearState() {
     for (let v of this.state.values()) {
       if (v.interval) {
         clearInterval(v.interval);
@@ -277,6 +388,12 @@ class AtlasRegistry {
     this.state = new Map();
   }
 
+  /**
+   * Stop background activity. This includes sending metrics to an atlas
+   * aggregator service and polling of meters.
+   *
+   * @return {undefined}
+   */
   stop() {
     const log = this.logger;
 
@@ -284,11 +401,18 @@ class AtlasRegistry {
     this.started = false;
     clearInterval(this.startId);
     this.startId = undefined;
-    this.publish(this);
+    AtlasRegistry._publish(this);
 
-    this._clearStateUpdates();
+    this._clearState();
   }
 
+
+  /**
+   * Get an array of measurements.
+   * @return {Array}
+   *   An array consisting of all measurements that were produced
+   *   by our registered meters.
+   */
   measurements() {
     let a = [];
 
@@ -298,11 +422,23 @@ class AtlasRegistry {
     return a;
   }
 
+  /**
+   * Get an array of registered meters.
+   * @return {any[]} An array consisting of all meters currently registered.
+   */
   meters() {
     return Array.from(this.metersMap.values());
   }
 
-  newId(name, tags) {
+
+  /**
+   * Creates an identifier for a meter.
+   *
+   * @param {string} name Description of the measurement that is being collected.
+   * @param {*} tags Other dimensions that can be used to classify the measurement.
+   * @return {MeterId} A new meter id.
+   */
+  createId(name, tags) {
     if (this.config.strictMode) {
       MeterId.validate(name, tags);
     }
@@ -313,7 +449,7 @@ class AtlasRegistry {
    * Schedule a task periodically.  See setInterval()
    *
    * @param {*} args - Arguments delegated to setInterval
-   * @returns {number}
+   * @returns {Object} A timeout for use with clearInterval
    */
   schedulePeriodically(args) {
     return setInterval.apply(this, arguments);

--- a/src/registry.js
+++ b/src/registry.js
@@ -6,8 +6,6 @@ const Gauge = require('./gauge');
 const Timer = require('./timer');
 const DistributionSummary = require('./dist_summary');
 const HttpClient = require('./http');
-const process = require("./nop_registry");
-const process = require("./nop_registry");
 
 // The default logger. In general users should provide their
 // own logger implementation that integrates with their setup

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const spectator = require('../');
+const Registry = require('../').Registry;
 const chai = require('chai');
 const assert = chai.assert;
 
 describe('spectator registry', () => {
   it('should provide counters', () => {
-    const registry = spectator.newRegistry();
+    const registry = new Registry();
     const counter = registry.counter('foo');
     counter.increment();
     const counterWithTag = registry.counter('foo', {
@@ -19,7 +19,7 @@ describe('spectator registry', () => {
   });
 
   it('should provide timers', () => {
-    const registry = spectator.newRegistry();
+    const registry = new Registry();
     const timer = registry.timer('timer');
     timer.record(1);
     const timerT = registry.timer('timer', {k: 'v2'});
@@ -31,7 +31,7 @@ describe('spectator registry', () => {
   });
 
   it('should provide distribution summaries', () => {
-    const registry = spectator.newRegistry();
+    const registry = new Registry();
     const ds = registry.distributionSummary('ds');
     ds.record(1000);
 
@@ -44,7 +44,7 @@ describe('spectator registry', () => {
   });
 
   it('should provide gauges', () => {
-    const registry = spectator.newRegistry();
+    const registry = new Registry();
     const g = registry.gauge('g');
     g.set(42);
     const gT = registry.gauge('g', {k: 'v'});

--- a/test/bucket_counter.test.js
+++ b/test/bucket_counter.test.js
@@ -17,7 +17,7 @@ describe('Bucket Counters', () => {
 
   it('basic operations', () => {
     const r = new Registry();
-    const c = BucketCounter.get(r, r.newId('test'), BucketFunctions.latency(4, 's'));
+    const c = BucketCounter.get(r, r.createId('test'), BucketFunctions.latency(4, 's'));
 
     c.record(3750 * 1e6);
     let meters = filter(r.meters(), 'test');

--- a/test/bucket_dist_summary.test.js
+++ b/test/bucket_dist_summary.test.js
@@ -17,7 +17,7 @@ describe('Bucket Distribution Summary', () => {
 
   it('basic operations', () => {
     const r = new Registry();
-    const c = BucketDistributionSummary.get(r, r.newId('test'), BucketFunctions.latency(4, 's'));
+    const c = BucketDistributionSummary.get(r, r.createId('test'), BucketFunctions.latency(4, 's'));
 
     c.record(3750 * 1e6);
     let meters = filter(r.meters(), 'test');

--- a/test/bucket_timer.test.js
+++ b/test/bucket_timer.test.js
@@ -17,7 +17,7 @@ describe('Bucket Timer', () => {
 
   it('basic operations', () => {
     const r = new Registry();
-    const c = BucketTimer.get(r, r.newId('test'), BucketFunctions.latency(4, 's'));
+    const c = BucketTimer.get(r, r.createId('test'), BucketFunctions.latency(4, 's'));
 
     c.record(3, 750 * 1e6);
     let meters = filter(r.meters(), 'test');

--- a/test/counter.test.js
+++ b/test/counter.test.js
@@ -39,4 +39,14 @@ describe('Counters', () => {
     assert.lengthOf(counter.measure(), 0); // resets
     assert.deepEqual([{id: id.withStat('count'), v: 3}], ms);
   });
+
+  it('should ignore add(0)', () => {
+    const id = new MeterId('c');
+    const counter = new Counter(id);
+    counter.add(0);
+    assert.equal(counter.count, 0);
+
+    counter.increment(0);
+    assert.equal(counter.count, 0);
+  });
 });

--- a/test/interval_counter.test.js
+++ b/test/interval_counter.test.js
@@ -15,7 +15,7 @@ describe('IntervalCounter', () => {
       return [0, 123];
     };
 
-    const counter = IntervalCounter.get(r, r.newId('ic'));
+    const counter = IntervalCounter.get(r, r.createId('ic'));
     counter.add(5);
     assert.equal(counter.count, 5);
 
@@ -48,8 +48,8 @@ describe('IntervalCounter', () => {
       }
       return [0, 123];
     };
-    const counter = IntervalCounter.get(r, r.newId('ic'));
-    const counter2 = IntervalCounter.get(r, r.newId('ic'));
+    const counter = IntervalCounter.get(r, r.createId('ic'));
+    const counter2 = IntervalCounter.get(r, r.createId('ic'));
     // both should refer to the same counter
     counter.add(1);
 
@@ -78,7 +78,7 @@ describe('IntervalCounter', () => {
     const r = new Registry({gaugePollingFrequency: 1, strictMode: true});
     const basicCounter = r.counter('ic');
 
-    assert.throws(() => IntervalCounter.get(r, r.newId('ic')),
+    assert.throws(() => IntervalCounter.get(r, r.createId('ic')),
       /found a Counter but was expecting an IntervalCounter/);
     basicCounter.add(2);
 
@@ -89,7 +89,7 @@ describe('IntervalCounter', () => {
 
   it('protects against the key used in the state map being used for other purposes', () => {
     const r = new Registry({gaugePollingFrequency: 1, strictMode: true});
-    const id = r.newId('ic');
+    const id = r.createId('ic');
     r.state.set(id.key, 'Foo');
     assert.throws(() => IntervalCounter.get(r, id),
       /found a String but was expecting an IntervalCounter/);
@@ -107,10 +107,10 @@ describe('IntervalCounter', () => {
       console.log(`ERROR: ${msg}`);
     };
 
-    const id = r.newId('ic');
+    const id = r.createId('ic');
     IntervalCounter.get(r, id);
 
-    const id2 = r.newId('ic2');
+    const id2 = r.createId('ic2');
     IntervalCounter.get(r, id2);
     assert.equal(errorCount, 2);
 

--- a/test/long_task_timer.test.js
+++ b/test/long_task_timer.test.js
@@ -14,7 +14,7 @@ describe('LongTaskTimer', () => {
       }
       return [0, 123];
     };
-    const timer = LongTaskTimer.get(r, r.newId('ltt'));
+    const timer = LongTaskTimer.get(r, r.createId('ltt'));
     const task = timer.start();
 
     setTimeout(() => {
@@ -46,8 +46,8 @@ describe('LongTaskTimer', () => {
       }
       return [0, 123];
     };
-    const timer = LongTaskTimer.get(r, r.newId('ltt'));
-    const timer2 = LongTaskTimer.get(r, r.newId('ltt'));
+    const timer = LongTaskTimer.get(r, r.createId('ltt'));
+    const timer2 = LongTaskTimer.get(r, r.createId('ltt'));
     // both should refer to the same timer
     const task = timer.start();
 
@@ -76,7 +76,7 @@ describe('LongTaskTimer', () => {
     const r = new Registry({gaugePollingFrequency: 1, strictMode: true});
     const basicTimer = r.timer('ltt');
 
-    assert.throws(() => LongTaskTimer.get(r, r.newId('ltt')),
+    assert.throws(() => LongTaskTimer.get(r, r.createId('ltt')),
       /found a Timer but was expecting a LongTaskTimer/);
     basicTimer.record(2, 0);
 
@@ -87,7 +87,7 @@ describe('LongTaskTimer', () => {
 
   it('protects against the key used in the state map being used for other purposes', () => {
     const r = new Registry({gaugePollingFrequency: 1, strictMode: true});
-    const id = r.newId('ltt');
+    const id = r.createId('ltt');
     r.state.set(id.key, 'Foo');
     assert.throws(() => LongTaskTimer.get(r, id),
       /found a String but was expecting a LongTaskTimer/);
@@ -105,7 +105,7 @@ describe('LongTaskTimer', () => {
       console.log(`ERROR: ${msg}`);
     };
 
-    const id = r.newId('ltt');
+    const id = r.createId('ltt');
     const t = LongTaskTimer.get(r, id);
     t.start();
     t.start();
@@ -113,7 +113,7 @@ describe('LongTaskTimer', () => {
     assert.equal(errorCount, 1);
 
 
-    const id2 = r.newId('ltt2');
+    const id2 = r.createId('ltt2');
     LongTaskTimer.get(r, id2);
     assert.equal(errorCount, 2);
 
@@ -122,7 +122,7 @@ describe('LongTaskTimer', () => {
 
   it('negative duration when stopping a non-existent task', () => {
     const r = new Registry({gaugePollingFrequency: 1, strictMode: false});
-    const t = LongTaskTimer.get(r, r.newId('ltt'));
+    const t = LongTaskTimer.get(r, r.createId('ltt'));
     const taskId = t.start();
     assert.isBelow(t.stop(taskId + 1), 0);
     r.stop();

--- a/test/percentile_dist_summary.test.js
+++ b/test/percentile_dist_summary.test.js
@@ -24,7 +24,7 @@ describe('Percentile Distribution Summaries', () => {
 
   it('constructor', () => {
     const r = new Registry();
-    const ds = PercentileDistributionSummary.get(r, r.newId('p'));
+    const ds = PercentileDistributionSummary.get(r, r.createId('p'));
     checkPercentiles(ds, 0);
   });
 
@@ -44,7 +44,7 @@ describe('Percentile Distribution Summaries', () => {
   it('builder with id', () => {
     const r = new Registry();
     const ds = new PercentileDistributionSummary.Builder(r)
-      .withId(r.newId('name', {k: 'v'})).build();
+      .withId(r.createId('name', {k: 'v'})).build();
     assert.equal(ds.id.key, 'name|k=v');
   });
 

--- a/test/percentile_timer.test.js
+++ b/test/percentile_timer.test.js
@@ -28,7 +28,7 @@ describe('Percentile Timers', () => {
 
   it('basic use', () => {
     const r = new Registry();
-    const id = r.newId('p');
+    const id = r.createId('p');
     const t = new PercentileTimer(r, id);
     checkPercentiles(t, 0);
   });
@@ -57,7 +57,7 @@ describe('Percentile Timers', () => {
 
   it('builder with id', () => {
     const r = new Registry();
-    const t = new PercentileTimer.Builder(r).withId(r.newId('name', {k: 'v'})).build();
+    const t = new PercentileTimer.Builder(r).withId(r.createId('name', {k: 'v'})).build();
     assert.equal(t.id.key, 'name|k=v');
   });
 
@@ -74,7 +74,7 @@ describe('Percentile Timers', () => {
     const expectedSum = N * (N - 1) / 2;
 
     const r = new Registry();
-    const timer = PercentileTimer.get(r, r.newId('name'));
+    const timer = PercentileTimer.get(r, r.createId('name'));
     for (let i = 0; i < N; ++i) {
       timer.record([0, millisToNanos(i)]);
     }

--- a/test/polled_meter.test.js
+++ b/test/polled_meter.test.js
@@ -23,7 +23,7 @@ describe('PolledMeter', () => {
 
   it('monitorValue using id', (done) => {
     const r = new Registry({gaugePollingFrequency: 1, strictMode: true});
-    const id = r.newId('foo');
+    const id = r.createId('foo');
     let x = 1;
     PolledMeter.using(r).withId(id).monitorValue(() => x);
     x = 42;
@@ -39,7 +39,7 @@ describe('PolledMeter', () => {
 
   it('monitorValue using multiple functions', (done) => {
     const r = new Registry({gaugePollingFrequency: 1, strictMode: true});
-    const id = r.newId('foo');
+    const id = r.createId('foo');
     let x = 1;
     PolledMeter.using(r).withId(id).monitorValue(() => x);
     PolledMeter.using(r).withId(id).monitorValue(() => x + 1);
@@ -77,7 +77,7 @@ describe('PolledMeter', () => {
 
   it('throws when mixing polled meters', () => {
     const r = new Registry({gaugePollingFrequency: 1, strictMode: true});
-    const id = r.newId('foo');
+    const id = r.createId('foo');
 
     let x = 100;
     PolledMeter.using(r).withId(id).monitorMonotonicNumber(() => x);
@@ -104,7 +104,7 @@ describe('PolledMeter', () => {
       errorCount++;
     };
 
-    const id = r.newId('foo');
+    const id = r.createId('foo');
     let x = 100;
     PolledMeter.using(r).withId(id).monitorMonotonicNumber(() => x);
     assert.equal(errorCount, 0);

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -48,16 +48,16 @@ describe('AtlasRegistry', () => {
 
   it('should only start if a publish uri is provided', () => {
     const r = newRegistry();
-    assert.isFalse(r.shouldStart());
+    assert.isFalse(r._shouldStart());
 
     const r2 = new AtlasRegistry({uri: 'http://localhost/foo'});
-    assert.isTrue(r2.shouldStart());
+    assert.isTrue(r2._shouldStart());
 
     r2.start();
-    assert.isFalse(r2.shouldStart()); // already started
+    assert.isFalse(r2._shouldStart()); // already started
 
     r2.stop();
-    assert.isTrue(r2.shouldStart()); // start after stop is ok
+    assert.isTrue(r2._shouldStart()); // start after stop is ok
 
     r.start(); // should be a nop
     assert.isFalse(r.started);
@@ -92,10 +92,10 @@ describe('AtlasRegistry', () => {
       for (let m of ms) {
         if (m.id.name === 'hack.ctr') {
           // unknown statistic
-          m.id = r.newId('hack.ctr', {statistic: 'foo'});
+          m.id = r.createId('hack.ctr', {statistic: 'foo'});
         } else if (m.id.name === 'hack.gauge') {
           // remove statistic
-          m.id = r.newId('hack.gauge');
+          m.id = r.createId('hack.gauge');
         }
         newMeasurements.push(m);
       }
@@ -263,6 +263,6 @@ describe('AtlasRegistry', () => {
       };
       assert.deepEqual(entries, [c, tmrCount, tmrTotal, tmrTotalSq, tmrMax]);
     };
-    r.publish(r);
+    AtlasRegistry._publish(r);
   });
 });


### PR DESCRIPTION
* export the classes users are expected to interact with instead of just
one function to create a registry.

* rename `registry.newId` to `registry.createId` for consistency with
spectator-java.

* Fix `counter.increment(0)` - was doing the equivalent of
`counter.increment()` which adds 1 to the current count.

* Start documenting the API using JSDoc