### PR TITLE
Hook for enabling/disabling publishing of metrics

### DIFF
--- a/src/registry.js
+++ b/src/registry.js
@@ -105,7 +105,9 @@ class Publisher {
     const ms = this.registryMeasurements();
     const log = this.registry.logger;
     const uri = this.registry.config.uri;
-    if (!uri) {
+    const enabled = this.registry.config.isEnabled();
+
+    if (!uri || !enabled) {
       return;
     }
 
@@ -151,6 +153,9 @@ class AtlasRegistry {
     }
     if (!this.config.strictMode) {
       this.config.strictMode = false; // replace undefined with false
+    }
+    if (!this.config.isEnabled) {
+      this.config.isEnabled = () => true;
     }
 
     this.metersMap = new Map();

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -280,9 +280,10 @@ describe('AtlasRegistry', () => {
     config.isEnabled = () => enabled;
 
     const r = new AtlasRegistry(config);
-    r.publisher.http.postJson = () => called++;
 
     let called = 0;
+    r.publisher.http.postJson = () => called++;
+
     r.counter('foo').increment();
     AtlasRegistry._publish(r);
     assert.equal(called, 1);

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -270,4 +270,40 @@ describe('AtlasRegistry', () => {
     };
     AtlasRegistry._publish(r);
   });
+
+  it('should only send measurements if enabled', () => {
+    const config = {};
+    config.commonTags = { 'nf.node': 'i-1234'};
+    config.uri = 'http://localhost:8080/publish';
+
+    let enabled = true;
+    config.isEnabled = () => enabled;
+
+    const r = new AtlasRegistry(config);
+    r.publisher.http.postJson = () => called++;
+
+    let called = 0;
+    r.counter('foo').increment();
+    AtlasRegistry._publish(r);
+    assert.equal(called, 1);
+
+    r.counter('foo').increment();
+    AtlasRegistry._publish(r);
+    assert.equal(called, 2);
+
+    enabled = false;
+    r.counter('foo').increment();
+    AtlasRegistry._publish(r);
+    assert.equal(called, 2);
+
+    enabled = true;
+    r.counter('foo').increment();
+    AtlasRegistry._publish(r);
+    assert.equal(called, 3);
+
+    enabled = false;
+    r.counter('foo').increment();
+    AtlasRegistry._publish(r);
+    assert.equal(called, 3);
+  });
 });


### PR DESCRIPTION
Add support to enable/disable publishing of metrics based on a function
passed in the config to the registry: `isEnabled()` which will return a
boolean value indicating whether metrics should be published.