### PR TITLE
Add trace and isLevelEnabled to the logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "Daniel Muino <dmuino@gmail.com>",
   "main": "src/index.js",
   "homepage": "https://github.org/Netflix/spectator-js",

--- a/src/percentile_buckets.js
+++ b/src/percentile_buckets.js
@@ -7,9 +7,7 @@ function initialize() {
   const DIGITS = 2;
   bucketValues.push(1, 2, 3);
 
-  let exp = DIGITS;
-
-  while (exp < 56) {
+  for (let exp = DIGITS; exp < 56; exp += DIGITS) {
     let current = Math.pow(2, exp);
     const delta = Math.floor(current / 3);
     let next = current * 4 - delta;
@@ -18,8 +16,8 @@ function initialize() {
       bucketValues.push(current);
       current += delta;
     }
-    exp += DIGITS;
   }
+
   // unfortunately we only get 56 bits of precision so
   // we generated this table with our C++ implementation
   // following the above algorithm

--- a/src/registry.js
+++ b/src/registry.js
@@ -24,6 +24,12 @@ class SimpleLogger {
     arguments[0] = 'ERROR: ' + arguments[0];
     console.log.apply(console, arguments);
   }
+
+  trace() {}
+
+  isLevelEnabled(level) {
+    return level !== 'trace';
+  }
 }
 
 // internal class used to publish measurements to an aggregator service
@@ -107,6 +113,11 @@ class Publisher {
     log.info('Sending ' + measurements.length + ' measurements to ' + uri);
     const payload = this.payloadForMeasurements(measurements);
     this.http.postJson(uri, payload);
+    if (log.isLevelEnabled('trace')) {
+      for (const m of measurements) {
+        log.trace(`Sent: ${m.id.key}=${m.v}`);
+      }
+    }
   }
 
   sendMetricsNow() {


### PR DESCRIPTION
Add an isLevelEnabled and trace to the logger interface. This is
supported by pino, and other logging frameworks. If trace is enabled we
will dump the measurements sent to the aggregator, which can be very
useful for debugging.