### PR TITLE
Add a simple configurable logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": "Daniel Muino <dmuino@gmail.com>",
   "main": "src/index.js",
   "homepage": "https://github.org/Netflix/spectator-js",

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const levels = {
+  trace: 10,
+  debug: 20,
+  info: 30,
+  warn: 40,
+  error: 50,
+  fatal: 60
+};
+
+function doNothing() {}
+
+function getLoggers(levelLabel) {
+  let level = levels[levelLabel || 'info'];
+  if (!level) {
+    level = levels.info;
+  }
+
+  const loggers = {
+    isLevelEnabled: (label) => levels[label] >= level
+  };
+
+  for (const label of Object.keys(levels)) {
+    const l = levels[label];
+    if (l < level) {
+      loggers[label] = doNothing;
+    } else {
+      loggers[label] = function() {
+        arguments[0] = label.toUpperCase() + ': ' + arguments[0];
+        console.log.apply(console, arguments);
+      };
+    }
+  }
+  return loggers;
+}
+
+module.exports = getLoggers;

--- a/src/registry.js
+++ b/src/registry.js
@@ -6,31 +6,7 @@ const Gauge = require('./gauge');
 const Timer = require('./timer');
 const DistributionSummary = require('./dist_summary');
 const HttpClient = require('./http');
-
-// The default logger. In general users should provide their
-// own logger implementation that integrates with their setup
-class SimpleLogger {
-  debug() {
-    arguments[0] = 'DEBUG: ' + arguments[0];
-    console.log.apply(console, arguments);
-  }
-
-  info() {
-    arguments[0] = 'INFO: ' + arguments[0];
-    console.log.apply(console, arguments);
-  }
-
-  error() {
-    arguments[0] = 'ERROR: ' + arguments[0];
-    console.log.apply(console, arguments);
-  }
-
-  trace() {}
-
-  isLevelEnabled(level) {
-    return level !== 'trace';
-  }
-}
+const getLoggers = require('./logger');
 
 // internal class used to publish measurements to an aggregator service
 class Publisher {
@@ -186,7 +162,7 @@ class AtlasRegistry {
     this.state = new Map();
     this.started = false;
     this.publisher = new Publisher(this);
-    this.logger = this.config.logger || new SimpleLogger();
+    this.logger = this.config.logger || getLoggers(this.config.logLevel);
     let commonTags = this.config.commonTags;
 
     if (!commonTags) {

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const chai = require('chai');
+const assert = chai.assert;
+const getLoggers = require('../src/logger');
+
+describe('Logger', () => {
+  it('default to info', () => {
+    const log = getLoggers();
+    assert.isTrue(log.isLevelEnabled('info'));
+    assert.isTrue(log.isLevelEnabled('error'));
+    assert.isFalse(log.isLevelEnabled('debug'));
+    assert.isFalse(log.isLevelEnabled('trace'));
+    assert.isFalse(log.isLevelEnabled('unknown'));
+
+    const l2 = getLoggers('x');
+    assert.isTrue(l2.isLevelEnabled('info'));
+    assert.isFalse(l2.isLevelEnabled('debug'));
+  });
+
+  it('should honor level', () => {
+    const log = getLoggers('debug');
+    assert.isTrue(log.isLevelEnabled('debug'));
+    assert.isFalse(log.isLevelEnabled('trace'));
+  });
+
+  it('should write something to stdout', () => {
+    const messages = [];
+    const f = console.log;
+    console.log = (msg) => messages.push(msg);
+
+    const log = getLoggers('warn');
+    log.info('Do nothing');
+    log.warn('Some warn');
+    log.error('Error msg');
+
+    assert.deepEqual(['WARN: Some warn', 'ERROR: Error msg'], messages);
+    console.log = f;
+  });
+});


### PR DESCRIPTION
This makes it possible to configure the verbosity of the logging done by
this module by passing a config option to the registry: `logLevel` with
the desired logging level. For example for very verbose logging you
could pass `logLevel: 'trace'`. The default level is `'info'`