### PR TITLE
Percentile tag values should be uppercase

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "author": "Daniel Muino <dmuino@gmail.com>",
   "main": "src/index.js",
   "homepage": "https://github.org/Netflix/spectator-js",

--- a/src/percentile_dist_summary.js
+++ b/src/percentile_dist_summary.js
@@ -4,7 +4,7 @@ const PercentileBuckets = require('./percentile_buckets');
 
 const percentiles = new Array(PercentileBuckets.length());
 for (let i = 0; i < percentiles.length; ++i) {
-  let hex = i.toString(16);
+  let hex = i.toString(16).toUpperCase();
   const hexLen = hex.length;
   const zerosNeeded = 4 - hexLen;
   for (let z = 0; z < zerosNeeded; ++z) {

--- a/src/percentile_timer.js
+++ b/src/percentile_timer.js
@@ -4,7 +4,7 @@ const PercentileBuckets = require('./percentile_buckets');
 
 const percentiles = new Array(PercentileBuckets.length());
 for (let i = 0; i < percentiles.length; ++i) {
-  let hex = i.toString(16);
+  let hex = i.toString(16).toUpperCase();
   const hexLen = hex.length;
   const zerosNeeded = 4 - hexLen;
   for (let z = 0; z < zerosNeeded; ++z) {


### PR DESCRIPTION
We were incorrectly generating the value for the percentile tags using
the lowercase hex string representation and it should have been upper
case