### PR TITLE
Use a gauge behavior for unknown statistics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "author": "Daniel Muino <dmuino@gmail.com>",
   "main": "src/index.js",
   "homepage": "https://github.org/Netflix/spectator-js",

--- a/src/registry.js
+++ b/src/registry.js
@@ -475,28 +475,20 @@ class AtlasRegistry {
 
 const ADD_OP = 0;
 const MAX_OP = 10;
-const UNKNOWN_OP = -1;
-const opsForStats = {
-  count: ADD_OP,
-  totalAmount: ADD_OP,
-  totalTime: ADD_OP,
-  totalOfSquares: ADD_OP,
-  percentile: ADD_OP,
-  max: MAX_OP,
-  gauge: MAX_OP,
-  activeTasks: MAX_OP,
-  duration: MAX_OP,
-  unknown: UNKNOWN_OP
+const counterStats = {
+  count: 1,
+  totalAmount: 1,
+  totalTime: 1,
+  totalOfSquares: 1,
+  percentile: 1
 };
 
 function opForMeasurement(measure) {
-  const stat = measure.id.tags.get('statistic') || 'unknown';
-  const op = opsForStats[stat];
-
-  if (op !== undefined) {
-    return op;
+  const stat = measure.id.tags.get('statistic') || '';
+  if (counterStats[stat]) {
+    return ADD_OP;
   }
-  return UNKNOWN_OP;
+  return MAX_OP;
 }
 
 function shouldSend(measure) {
@@ -506,10 +498,7 @@ function shouldSend(measure) {
     return measure.v > 0;
   }
 
-  if (op === MAX_OP) {
-    return !Number.isNaN(measure.v);
-  }
-  return false;
+  return !Number.isNaN(measure.v);
 }
 
 module.exports = AtlasRegistry;

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -78,7 +78,7 @@ describe('AtlasRegistry', () => {
     assert.equal(rMap.commonTags.size, 2);
   });
 
-  it('should ignore meters with unknown stats', () => {
+  it('should assume gauges for unknown stats', () => {
     const r = newRegistry();
     r.counter('ctr').increment();
     assert.lengthOf(r.publisher.registryMeasurements(), 1);
@@ -107,7 +107,7 @@ describe('AtlasRegistry', () => {
       return newMeasurements;
     };
     const ms = r.publisher.registryMeasurements();
-    assert.lengthOf(ms, 2);
+    assert.lengthOf(ms, 4);
   });
 
   it('publisher should build a string table', () => {


### PR DESCRIPTION
Previously we were ignoring meters with unknown or missing statistic tag
values. Now we match the java/golang behavior of sending those as gauges
by default.