### PR TITLE
Add a few deprecated aliases to help with adoption

### DIFF
--- a/src/gauge.js
+++ b/src/gauge.js
@@ -46,9 +46,9 @@ class Gauge {
 
   /**
    *
-   * @deprecated Use set instead.
-   *
    * Set the current gauge value to the specified number.
+   *
+   * @deprecated Use set instead.
    *
    * @param {number} value Number to be used when reporting the value to atlas.
    * @return {undefined}

--- a/src/gauge.js
+++ b/src/gauge.js
@@ -34,6 +34,30 @@ class Gauge {
   }
 
   /**
+   * Get the current value.
+   *
+   * @deprecated Use get() instead.
+   *
+   * @return {number} The current value for this gauge.
+   */
+  value() {
+    return this.value_;
+  }
+
+  /**
+   *
+   * @deprecated Use set instead.
+   *
+   * Set the current gauge value to the specified number.
+   *
+   * @param {number} value Number to be used when reporting the value to atlas.
+   * @return {undefined}
+   */
+  update(value) {
+    this.value_ = value;
+  }
+
+  /**
    * Get the measurements for this gauge.
    *
    * @return {Object[]} Either an empty array or an array with

--- a/src/registry.js
+++ b/src/registry.js
@@ -335,6 +335,21 @@ class AtlasRegistry {
   }
 
   /**
+   * Measures the rate of some activity. A counter is for continuously incrementing sources like
+   * the number of requests that are coming into a server.
+   *
+   * @deprecated Use counter instead. This is kept for backwards compatibility only
+   *
+   * @param {*} nameOrId either a string with a name, or a base id
+   * @param {*} tags an object or Map with tags
+   * @return {Counter} A counter that is registered with this registry.
+   */
+  dcounter(nameOrId, tags) {
+    const meterId = this._getId(nameOrId, tags);
+    return this._newMeter(meterId, Counter);
+  }
+
+  /**
    * Measures the rate and variation in amount for some activity. For example, it could be used to
    * get insight into the variation in response sizes for requests to a server.
    *
@@ -343,6 +358,21 @@ class AtlasRegistry {
    * @return {DistributionSummary} A distribution summary that is registered with this registry.
    */
   distributionSummary(nameOrId, tags) {
+    const meterId = this._getId(nameOrId, tags);
+    return this._newMeter(meterId, DistributionSummary);
+  }
+
+  /**
+   * Measures the rate and variation in amount for some activity. For example, it could be used to
+   * get insight into the variation in response sizes for requests to a server.
+   *
+   * @deprecated Use distributionSummary instead. This is kept for backwards compatibility only
+   *
+   * @param {*} nameOrId either a string with a name, or a base id
+   * @param {*} tags an object or Map with tags
+   * @return {DistributionSummary} A distribution summary that is registered with this registry.
+   */
+  distSummary(nameOrId, tags) {
     const meterId = this._getId(nameOrId, tags);
     return this._newMeter(meterId, DistributionSummary);
   }

--- a/test/gauge.test.js
+++ b/test/gauge.test.js
@@ -32,4 +32,14 @@ describe('Gauges', () => {
     assert.lengthOf(gauge.measure(), 0); // resets
     assert.deepEqual([{id: id.withStat('gauge'), v: 2}], ms);
   });
+
+  it('should honor deprecated methods', () => {
+    const id = new MeterId('g');
+    const g = new Gauge(id);
+    g.update(42);
+    assert.equal(g.value(), 42);
+
+    g.update(21);
+    assert.equal(g.value(), 21);
+  });
 });

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -335,4 +335,18 @@ describe('AtlasRegistry', () => {
     assert.equal(called, expectedBatches);
     assert.equal(sent, numCounters);
   });
+
+  it('should honor backwards compat aliases', () => {
+    const r = new AtlasRegistry({});
+    const ds = r.distributionSummary('name');
+    const ds2 = r.distSummary('name');
+
+    ds.record(100);
+    assert.equal(ds2.totalAmount, 100);
+
+    const c = r.counter('ctr');
+    c.increment(1.1);
+    const d = r.dcounter('ctr');
+    assert(d.count, 1.1);
+  });
 });


### PR DESCRIPTION
Add a few deprecated aliases that help with migrating from atlasclient
to spectator-js