### PR TITLE
feat: waits for last publishing before shutdown + expose publisher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator",
-  "version": "0.0.1",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -196,10 +196,9 @@
       "dev": true
     },
     "async": {
-      "version": "0.2.10",
-      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/async/-/async-0.2.10.tgz",
-      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-      "dev": true
+      "version": "3.1.0",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/async/-/async-3.1.0.tgz",
+      "integrity": "sha1-QrOxKuG3SSe1IX2MABa6r2JGN3I="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -2423,7 +2422,6 @@
       "version": "0.4.23",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha1-KXhx9jvlB63Pv8pxXQzQ7thOmmM=",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -3214,6 +3212,31 @@
       "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=",
       "dev": true
     },
+    "needle": {
+      "version": "2.4.0",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/needle/-/needle-2.4.0.tgz",
+      "integrity": "sha1-aDPnSXXERGQlkOFadQKIxfk5tXw=",
+      "requires": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+        }
+      }
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/negotiator/-/negotiator-0.6.1.tgz",
@@ -3929,8 +3952,12 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
-      "dev": true
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
     },
     "semver": {
       "version": "5.6.0",
@@ -4719,6 +4746,14 @@
         "mkdirp": "0.x.x",
         "ncp": "0.4.x",
         "rimraf": "2.x.x"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
+        }
       }
     },
     "utils-merge": {
@@ -4849,6 +4884,12 @@
         "stack-trace": "0.0.x"
       },
       "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
+        },
         "colors": {
           "version": "0.6.2",
           "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/colors/-/colors-0.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "ssh://git@github.com:Netflix/spectator-js.git"
   },
+  "engines": {
+    "node": ">6.4.0"
+  },
   "license": "Apache-2.0",
   "devDependencies": {
     "body-parser": "^1.18.3",
@@ -27,5 +30,9 @@
   },
   "files": [
     "src/*"
-  ]
+  ],
+  "dependencies": {
+    "async": "^3.1.0",
+    "needle": "^2.4.0"
+  }
 }

--- a/src/publisher.js
+++ b/src/publisher.js
@@ -1,0 +1,203 @@
+/**
+ * @module publisher
+ */
+'use strict';
+
+const HttpClient = require('./http');
+const async = require('async');
+
+/**
+ * internal class used to publish measurements to an aggregator service
+ *
+ * @class Publisher
+ * @protected
+ */
+class Publisher {
+  /**
+   * @constructor
+   * @param {AtlasRegistry} registry spectator registry instance
+   */
+  constructor(registry) {
+    this.registry = registry;
+    this.http = new HttpClient(registry);
+  }
+
+  /**
+   * Build a string table from the list of measurements
+   * Unique words are identified, and assigned a number starting from 0 based
+   * on their lexicographical order
+   *
+   * @param {object[]} measurements measurements to be published
+   * @return {object}
+   */
+  buildStringTable(measurements) {
+    let commonTags = this.registry.commonTags;
+    let table = {};
+
+    for (let [key, value] of commonTags) {
+      table[key] = 0;
+      table[value] = 0;
+    }
+    table.name = 0;
+
+    for (let m of measurements) {
+      table[m.id.name] = 0;
+
+      for (let [k, v] of m.id.tags) {
+        table[k] = 0;
+        table[v] = 0;
+      }
+    }
+    let keys = Object.keys(table);
+    keys.sort();
+    keys.forEach((v, idx) => {
+      table[v] = idx;
+    });
+    return table;
+  }
+
+  /**
+   * mutates the payload parameter with measurements
+   *
+   * @param {any[]} payload request payload
+   * @param {object} table string table
+   * @param {object} measure measure to be added to the payload
+   * @return {void}
+   */
+  appendMeasurement(payload, table, measure) {
+    const op = opForMeasurement(measure);
+    const commonTags = this.registry.commonTags;
+    const tags = measure.id.tags;
+    const len = tags.size + 1 + commonTags.size;
+    payload.push(len);
+
+    for (let [k, v] of commonTags) {
+      payload.push(table[k]);
+      payload.push(table[v]);
+    }
+
+    for (let [k, v] of tags) {
+      payload.push(table[k]);
+      payload.push(table[v]);
+    }
+
+    payload.push(table.name);
+    payload.push(table[measure.id.name]);
+    payload.push(op);
+    payload.push(measure.v);
+  }
+
+  /**
+   *
+   * @param {object[]} measurements measurements to be published
+   * @return {any[]}
+   */
+  payloadForMeasurements(measurements) {
+    const table = this.buildStringTable(measurements);
+    const strings = Object.keys(table);
+    strings.sort();
+
+    const payload = [].concat(strings.length, strings);
+    for (let m of measurements) {
+      this.appendMeasurement(payload, table, m);
+    }
+    return payload;
+  }
+
+  /**
+   * gets measurements
+   * @return {object[]}
+   */
+  registryMeasurements() {
+    return this.registry.measurements().filter(shouldSend);
+  }
+
+  /**
+   * makes http request to spectator and sends accumulated measurements
+   * @private
+   * @param {object[]} measurements measurements to be published
+   * @param {function(e: Error, res: any): void} [cb = ()=> {}] callback function
+   * @return {void}
+   */
+  _sendMeasurements(measurements, cb = () => {}) {
+    const log = this.registry.logger;
+    const uri = this.registry.config.uri;
+    log.debug('Sending ' + measurements.length + ' measurements to ' + uri);
+    const payload = this.payloadForMeasurements(measurements);
+    this.http.postJson(uri, payload, cb);
+    if (typeof log.isLevelEnabled === 'function' && log.isLevelEnabled('trace')) {
+      for (const m of measurements) {
+        log.trace(`Sent: ${m.id.key}=${m.v}`);
+      }
+    }
+  }
+
+  /**
+   * flushes accumulated measurements
+   * @param {function(e: Error, res: any): void} [cb = ()=> {}] callback function
+   * @return {void}
+   */
+  sendMetricsNow(cb = () => {}) {
+    const batchSize = this.registry.config.batchSize;
+    const measurements = this.registryMeasurements();
+    const log = this.registry.logger;
+    const uri = this.registry.config.uri;
+    const enabled = this.registry.config.isEnabled();
+
+    if (!uri || !enabled) {
+      return;
+    }
+
+    if (measurements.length === 0) {
+      log.debug('No measurements to send');
+    } else {
+
+      let batches = [];
+      for (let i = 0; i < measurements.length; i += batchSize) {
+        batches.push(measurements.slice(i, i + batchSize));
+      }
+
+      async.map(batches, this._sendMeasurements.bind(this), function(err) {
+        cb(err);
+      });
+    }
+  }
+}
+
+const ADD_OP = 0;
+const MAX_OP = 10;
+const counterStats = {
+  count: 1,
+  totalAmount: 1,
+  totalTime: 1,
+  totalOfSquares: 1,
+  percentile: 1
+};
+
+/**
+ * @param {object} measure measurement
+ * @return {number}
+ */
+function opForMeasurement(measure) {
+  const stat = measure.id.tags.get('statistic') || '';
+  if (counterStats[stat]) {
+    return ADD_OP;
+  }
+  return MAX_OP;
+}
+
+/**
+ * @param {object} measure measurement
+ * @return {boolean}
+ */
+function shouldSend(measure) {
+  const op = opForMeasurement(measure);
+
+  if (op === ADD_OP) {
+    return measure.v > 0;
+  }
+
+  return !Number.isNaN(measure.v);
+}
+
+module.exports = Publisher;


### PR DESCRIPTION
### Why?

On graceful shutdown we want make sure the last `_publish` triggered by `stop` succeeds (or fails) before we kill the process. Allowing custom publishers provides long term flexibility.

### How?

1) breaks out publisher, so it can be extended by implementations
2) adds `config.publisher` for a custom Publisher in registry
3) waits for optional callback in `registry.stop` and `publisher`
4) replace handcrafted http client with will maintained lean module

### Tests:

The test suit is very comprehensive and the only needed to add a test to check the error condition.

### NOTE:

 this commit adds two lean dependencies to spectator-js:

1) `needle` (lean http client that has a callback interface)
2) `async` to manage the partitioned async state of waiting for multiple async calls