### PR TITLE
fix(publisher): consistent callback on sendMetricsNow

### DIFF
--- a/src/publisher.js
+++ b/src/publisher.js
@@ -145,22 +145,23 @@ class Publisher {
     const enabled = this.registry.config.isEnabled();
 
     if (!uri || !enabled) {
-      return;
+      log.warn(`Unable to send metrics to ${uri} (enabled=${enabled})`);
+      return cb();
     }
 
     if (measurements.length === 0) {
       log.debug('No measurements to send');
-    } else {
-
-      let batches = [];
-      for (let i = 0; i < measurements.length; i += batchSize) {
-        batches.push(measurements.slice(i, i + batchSize));
-      }
-
-      async.map(batches, this._sendMeasurements.bind(this), function(err) {
-        cb(err);
-      });
+      return cb();
     }
+
+    let batches = [];
+    for (let i = 0; i < measurements.length; i += batchSize) {
+      batches.push(measurements.slice(i, i + batchSize));
+    }
+
+    return async.map(batches, this._sendMeasurements.bind(this), function(err) {
+      cb(err);
+    });
   }
 }
 

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -308,6 +308,34 @@ describe('AtlasRegistry', () => {
     assert.equal(called, 3);
   });
 
+  it('should call callback if not enabled', (done) => {
+    const config = {};
+    config.uri = 'http://localhost:8080/publish';
+
+    let enabled = true;
+    config.isEnabled = () => enabled;
+
+    const r = new AtlasRegistry(config);
+
+    r.stop(function() {
+      return done();
+    });
+  });
+
+  it('should call callback if there is nothing to send', (done) => {
+    const config = {};
+    config.uri = 'http://localhost:8080/publish';
+
+    let enabled = false;
+    config.isEnabled = () => enabled;
+
+    const r = new AtlasRegistry(config);
+
+    r.stop(function() {
+      return done();
+    });
+  });
+
   it('should batch measurements', (done) => {
     const config = {};
     config.uri = 'http://localhost:8080/publish';


### PR DESCRIPTION
**Why?**
callback was not being called on stop if there were no metrics to flush or if spectator was disabled. This was causing NQ to graceful shutdown to fail with a timeout.

**How?**
consistently calling callback fix the issue. As per @hekike suggestion, a warning is issued if it can't flush metrics because spectator is disabled.