### PR TITLE
fix(performance): don't create objects when not needed

### DIFF
--- a/src/meter_id.js
+++ b/src/meter_id.js
@@ -3,15 +3,14 @@
 class MeterId {
   constructor(name, tags) {
     this.name = name;
-    let t = new Map();
 
     if (!tags) {
-      this.tags = t;
+      this.tags = new Map();
     } else if (tags instanceof Map) {
       this.tags = tags;
     } else {
       // assume object
-      this.tags = t;
+      this.tags = new Map();
 
       for (let key of Object.keys(tags)) {
         this.tags.set(key, tags[key]);


### PR DESCRIPTION
The canary we run on NQ showed a spike on CPU usage, I didn't find anything obvious, but I did find these possible performance improvements (without any functionality change).

Because of tags we have to create quite a few metrics per request, so if we can fetch the metric from the map without having to create a new metric first, it might render some (maybe minimal) improvements... 