### PR TITLE
fix(performance): fix leak on static get methods

### DIFF
--- a/src/percentile_timer.js
+++ b/src/percentile_timer.js
@@ -13,6 +13,51 @@ for (let i = 0; i < percentiles.length; ++i) {
   percentiles[i] = 'T' + hex;
 }
 
+class PercentileTimerBuilder {
+  constructor(registry) {
+    this.registry = registry;
+    this.min = 10 * 1e6; // 10 ms
+    this.max = 60 * 1e9; // 1 min
+  }
+  withId(id) {
+    this.id = id;
+    return this;
+  }
+  withName(name) {
+    this.name = name;
+    return this;
+  }
+  withTags(tags) {
+    this.tags = tags;
+    return this;
+  }
+  withRangeSeconds(min, max) {
+    this.min = min * 1e9;
+    this.max = max * 1e9;
+    return this;
+  }
+  withRangeMilliseconds(min, max) {
+    this.min = min * 1e6;
+    this.max = max * 1e6;
+    return this;
+  }
+  withRangeNanoseconds(min, max) {
+    this.min = min;
+    this.max = max;
+    return this;
+  }
+  build() {
+    let id;
+    if (this.id) {
+      id = this.id;
+    } else {
+      id = this.registry.createId(this.name, this.tags);
+    }
+    /* eslint no-use-before-define: ["error", { "classes": false }] */
+    return new PercentileTimer(this.registry, id, this.min, this.max);
+  }
+}
+
 /**
  * Timer that buckets the counts to allow for estimating percentiles. This timer type will track
  * the data distribution for the timer by maintaining a set of counters. The distribution
@@ -55,50 +100,7 @@ class PercentileTimer {
   }
 
   static get Builder() {
-    class Builder {
-      constructor(registry) {
-        this.registry = registry;
-        this.min = 10 * 1e6; // 10 ms
-        this.max = 60 * 1e9; // 1 min
-      }
-      withId(id) {
-        this.id = id;
-        return this;
-      }
-      withName(name) {
-        this.name = name;
-        return this;
-      }
-      withTags(tags) {
-        this.tags = tags;
-        return this;
-      }
-      withRangeSeconds(min, max) {
-        this.min = min * 1e9;
-        this.max = max * 1e9;
-        return this;
-      }
-      withRangeMilliseconds(min, max) {
-        this.min = min * 1e6;
-        this.max = max * 1e6;
-        return this;
-      }
-      withRangeNanoseconds(min, max) {
-        this.min = min;
-        this.max = max;
-        return this;
-      }
-      build() {
-        let id;
-        if (this.id) {
-          id = this.id;
-        } else {
-          id = this.registry.createId(this.name, this.tags);
-        }
-        return new PercentileTimer(this.registry, id, this.min, this.max);
-      }
-    }
-    return Builder;
+    return PercentileTimerBuilder;
   }
 
   _counterFor(i) {

--- a/src/polled_meter.js
+++ b/src/polled_meter.js
@@ -64,80 +64,80 @@ class ValueState {
   }
 }
 
-class PolledMeter {
-  static using(registry) {
-    class Builder {
-      constructor(r) {
-        this.registry = r;
-      }
+class PolledMeterBuilder {
+  constructor(r) {
+    this.registry = r;
+  }
 
-      withId(id) {
-        this.id = id;
-        return this;
-      }
+  withId(id) {
+    this.id = id;
+    return this;
+  }
 
-      withName(name) {
-        this.name = name;
-        return this;
-      }
+  withName(name) {
+    this.name = name;
+    return this;
+  }
 
-      withTags(tags) {
-        this.tags = tags;
-        return this;
-      }
+  withTags(tags) {
+    this.tags = tags;
+    return this;
+  }
 
-      monitorValue(fun) {
-        let id;
-        const r = this.registry;
-        if (this.id) {
-          id = this.id;
-        } else {
-          id = r.createId(this.name, this.tags);
-        }
-        const gauge = r.gauge(id);
-        const state = r.state;
-        let c = state.get(id.key);
-        if (!c) {
-          c = new ValueState(gauge);
-          state.set(id.key, c);
-        } else {
-          if (c.constructor.name !== 'ValueState') {
-            registry.throwTypeError(id, c.constructor.name, 'ValueState', 'PolledMeter');
-          }
-        }
-        if (c.constructor.name === 'ValueState') {
-          c.add(fun);
-          c.schedule(r);
-        }
-      }
-
-      monitorMonotonicNumber(fun) {
-        let id;
-        const r = this.registry;
-        if (this.id) {
-          id = this.id;
-        } else {
-          id = r.createId(this.name, this.tags);
-        }
-        const counter = r.counter(id);
-        const state = r.state;
-        let c = state.get(id.key);
-        if (!c) {
-          c = new CounterState(counter);
-          state.set(id.key, c);
-        } else {
-          if (c.constructor.name !== 'CounterState') {
-            registry.throwTypeError(id, c.constructor.name, 'ValueState', 'PolledMeter');
-          }
-        }
-        if (c.constructor.name === 'CounterState') {
-          c.add(fun);
-          c.schedule(r);
-        }
+  monitorValue(fun) {
+    let id;
+    const r = this.registry;
+    if (this.id) {
+      id = this.id;
+    } else {
+      id = r.createId(this.name, this.tags);
+    }
+    const gauge = r.gauge(id);
+    const state = r.state;
+    let c = state.get(id.key);
+    if (!c) {
+      c = new ValueState(gauge);
+      state.set(id.key, c);
+    } else {
+      if (c.constructor.name !== 'ValueState') {
+        r.throwTypeError(id, c.constructor.name, 'ValueState', 'PolledMeter');
       }
     }
+    if (c.constructor.name === 'ValueState') {
+      c.add(fun);
+      c.schedule(r);
+    }
+  }
 
-    return new Builder(registry);
+  monitorMonotonicNumber(fun) {
+    let id;
+    const r = this.registry;
+    if (this.id) {
+      id = this.id;
+    } else {
+      id = r.createId(this.name, this.tags);
+    }
+    const counter = r.counter(id);
+    const state = r.state;
+    let c = state.get(id.key);
+    if (!c) {
+      c = new CounterState(counter);
+      state.set(id.key, c);
+    } else {
+      if (c.constructor.name !== 'CounterState') {
+        r.throwTypeError(id, c.constructor.name, 'ValueState', 'PolledMeter');
+      }
+    }
+    if (c.constructor.name === 'CounterState') {
+      c.add(fun);
+      c.schedule(r);
+    }
+  }
+}
+
+class PolledMeter {
+  static using(registry) {
+    return new PolledMeterBuilder(registry);
   }
 }
 


### PR DESCRIPTION
Classes are not garbage collected by V8 (tested up to V8 7.6, Node.js
v12.10.0). V8 also will re-create a class every time the class
declaration code is executed. As a result, each time users call
PerformanceTimer.Builder we'll create a new class, which will be stored
on the heap and never collected, thus leading to a memory leak.

This commit moves the class declaration on all three places we were
using the static get class pattern to outside the function, ensuring we
only declare the class once. The commit also rename `Builder` classes
with a more descriptive name, to ensure diagnostic tools can distinguish
those three classes. The public API remains unchanged.