### PR TITLE
Avoid the concat method in favor of push

### DIFF
--- a/src/registry.js
+++ b/src/registry.js
@@ -355,7 +355,7 @@ class AtlasRegistry {
     let a = [];
 
     for (let meter of this.metersMap.values()) {
-      a = a.concat(meter.measure());
+      Array.prototype.push.apply(a, meter.measure());
     }
     return a;
   }


### PR DESCRIPTION
Apparently the `concat` method is significantly slower than using
`push` repeatedly.

https://dev.to/uilicious/javascript-array-push-is-945x-faster-than-array-concat-1oki