### PR TITLE
Use ipc metric names and retry 503 errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
 - '6'
 - '10'
+- '13'
 script:
 - make
 after_success:

--- a/src/log_entry.js
+++ b/src/log_entry.js
@@ -1,0 +1,124 @@
+'use strict';
+
+const PercentileTimer = require('./percentile_timer');
+
+class LogEntry {
+  /**
+   * @constructor
+   * @param {AtlasRegistry} registry spectator registry instance
+   * @param {string} method GET | POST, etc.
+   * @param {string} url URL used as the destination for the method
+   */
+  constructor(registry, method, url) {
+    this.registry = registry;
+    this.start = registry.hrtime();
+    const tags = {
+        owner: 'spectator-js',
+        'ipc.endpoint': pathFromUrl(url),
+        'http.method': method,
+        'http.status': '-1'
+      };
+    this.id = registry.createId('ipc.client.call', tags);
+  }
+
+  /**
+   * Update a percentile timer based on the current log entry
+   * @return {void}
+   */
+  log() {
+    new PercentileTimer.Builder(this.registry)
+      .withId(this.id)
+      .withRangeMilliseconds(1, 5000).build()
+      .record(this.registry.hrtime(this.start));
+  }
+
+  /**
+   * Set the http status code for this log entry
+   *
+   * @param {number} code http status code
+   * @return {void}
+   */
+  setStatusCode(code) {
+    this.id = this.id.withTag('http.status', code.toString());
+  }
+
+  /**
+   * Record the attempt number for the request, and whether it is final
+   *
+   * @param {number} attemptNumber Attempt number
+   * @param {boolean} final Whether this is the final request, or more retries are expected
+   * @return {void}
+   */
+  setAttempt(attemptNumber, final) {
+    this.id = this.id.withTag('ipc.attempt', attempt(attemptNumber))
+      .withTag('ipc.attempt.final', final.toString());
+  }
+
+  /**
+   * Mark the entry as an error
+   *
+   * @param {string} error Error type (should be a single word)
+   * @return {void}
+   */
+  setError(error) {
+    this.id = this.id.withTag('ipc.result', 'failure').withTag('ipc.status', error);
+  }
+
+  /**
+   * Mark the entry as successful
+   * @return {void}
+   */
+  setSuccess() {
+    const ipcSuccess = 'success';
+    this.id = this.id.withTag('ipc.result', ipcSuccess).withTag('ipc.result', ipcSuccess);
+  }
+}
+
+/**
+ * Get the string representation of an attempt number
+ * @param {Number} attemptNumber Attempt number
+ * @return {string} Representation of the attempt number
+ */
+function attempt(attemptNumber) {
+  switch (attemptNumber) {
+    case 0:
+      return 'initial';
+    case 1:
+      return 'second';
+    default:
+      return 'third_up';
+  }
+}
+
+function pathFromUrl(url) {
+  if (url.length === 0) {
+    return '/';
+  }
+
+  const protoEnd = url.indexOf(':');
+  if (protoEnd < 0) {
+    // no protocol, assume just a path
+    return url;
+  }
+
+  const protocolLen = url.length - protoEnd;
+  if (protocolLen < 3) {
+    return url;
+  }
+
+  // find the path, skipping over protocol://
+  const pathBegin = url.indexOf('/', protoEnd + 3);
+  if (pathBegin < 0) {
+    return '/';
+  }
+
+  const queryBegin = url.indexOf('?', pathBegin + 1);
+  if (queryBegin < 0) {
+    // no query component
+    return url.substring(pathBegin);
+  }
+
+  return url.substring(pathBegin, queryBegin);
+}
+
+module.exports = LogEntry;

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -21,11 +21,11 @@ describe('http client', () => {
     const listener = server.listen(() => {
       const port = listener.address().port;
       console.log('Listening on ' + port);
-      h.postJson('http://localhost:' + port + '/json',
+      h.postJson('http://localhost:' + port + '/foo-endpoint',
         {foo: 'bar'});
     });
 
-    server.post('/json', (req, res) => {
+    server.post('/foo-endpoint', (req, res) => {
       const payload = req.body;
       res.send(JSON.stringify({
         ok: 1
@@ -39,14 +39,16 @@ describe('http client', () => {
 
         for (let m of measurements) {
           const name = m.id.name;
-
-          if (name === 'http.req.complete') {
+          if (name !== 'ipc.client.call') {
+            assert.fail(name, 'ipc.client.call', `Unexpected measurement: ${m.id.key}`);
+          } else {
             ++timerCount;
-            assert.equal(m.id.tags.get('status'), '2xx');
-            assert.equal(m.id.tags.get('statusCode'), '200');
+            assert.equal(m.id.tags.get('ipc.result'), 'success');
+            assert.equal(m.id.tags.get('http.status'), '200');
+            assert.equal(m.id.tags.get('ipc.endpoint'), '/foo-endpoint');
           }
         }
-        assert.equal(timerCount, 4);
+        assert.equal(timerCount, 5);
         listener.close();
         done();
       }, 10);
@@ -65,11 +67,12 @@ describe('http client', () => {
     const listener = server.listen(() => {
       const port = listener.address().port;
       console.log('Listening on ' + port);
-      h.postJson('http://localhost:' + port + '/json',
+      h.postJson('http://localhost:' + port + '/json503?',
         {foo: 'bar'});
     });
 
-    server.post('/json', (req, res) => {
+    let attemptNumber = 0;
+    server.post('/json503', (req, res) => {
       const payload = req.body;
       res.status(503);
       res.send(JSON.stringify({
@@ -77,6 +80,74 @@ describe('http client', () => {
       }));
       res.end();
       assert.deepEqual({foo: 'bar'}, payload);
+      attemptNumber++;
+      if (attemptNumber < 4) {
+        return;
+      }
+
+      setTimeout(() => {
+        const measurements = r.measurements();
+        console.log(`Got ${measurements.length} measurements`);
+        let timerCount = 0;
+        let finalCount = 0;
+
+        for (let m of measurements) {
+          const name = m.id.name;
+
+          if (name !== 'ipc.client.call') {
+            assert.fail(m.id.name, 'ipc.client.call', `Unexpected measurement ${m.id.key}`);
+          } else {
+            ++timerCount;
+            assert.equal(m.id.tags.get('http.status'), '503');
+            assert.equal(m.id.tags.get('ipc.status'), 'http_error');
+            assert.equal(m.id.tags.get('ipc.result'), 'failure');
+            assert.equal(m.id.tags.get('ipc.endpoint'), '/json503');
+            if (m.id.tags.get('ipc.attempt.final') === 'true') {
+              ++finalCount;
+            }
+          }
+        }
+        assert.equal(timerCount, 4 * 5);
+        assert.equal(finalCount, 5);
+        listener.close();
+        done();
+      }, 10);
+    });
+  });
+
+  it('handle retries', (done) => {
+    const r = new AtlasRegistry();
+    const h = new HttpClient(r);
+    const server = express();
+    server.use(bodyParser.json({
+      type: 'application/json',
+      limit: '8mb'
+    }));
+
+    const listener = server.listen(() => {
+      const port = listener.address().port;
+      console.log('Listening on ' + port);
+      h.postJson('http://localhost:' + port + '/json503?',
+        {foo: 'bar'});
+    });
+
+    let attemptNumber = 0;
+    server.post('/json503', (req, res) => {
+      const payload = req.body;
+      if (attemptNumber === 0) {
+        res.status(503);
+      } else {
+        res.status(200);
+      }
+
+      res.send(JSON.stringify({err: attemptNumber === 0}));
+      res.end();
+      assert.deepEqual({foo: 'bar'}, payload);
+      attemptNumber++;
+      if (attemptNumber < 2) {
+        return;
+      }
+
       setTimeout(() => {
         const measurements = r.measurements();
         console.log(`Got ${measurements.length} measurements`);
@@ -85,13 +156,30 @@ describe('http client', () => {
         for (let m of measurements) {
           const name = m.id.name;
 
-          if (name === 'http.req.complete') {
+          if (name !== 'ipc.client.call') {
+            assert.fail(m.id.name, 'ipc.client.call', `Unexpected measurement ${m.id.key}`);
+          } else {
             ++timerCount;
-            assert.equal(m.id.tags.get('status'), '5xx');
-            assert.equal(m.id.tags.get('statusCode'), '503');
+            const isFinal = m.id.tags.get('ipc.attempt.final') === 'true';
+            let expectedResult;
+            let expectedStatus;
+            if (isFinal) {
+              expectedStatus = '200';
+              expectedResult = 'success';
+              assert.equal(m.id.tags.get('ipc.attempt'), 'second');
+            } else {
+              expectedStatus = '503';
+              expectedResult = 'failure';
+              assert.equal(m.id.tags.get('ipc.status'), 'http_error');
+              assert.equal(m.id.tags.get('ipc.attempt'), 'initial');
+            }
+
+            assert.equal(m.id.tags.get('http.status'), expectedStatus);
+            assert.equal(m.id.tags.get('ipc.result'), expectedResult);
+            assert.equal(m.id.tags.get('ipc.endpoint'), '/json503');
           }
         }
-        assert.equal(timerCount, 4);
+        assert.equal(timerCount, 2 * 5);
         listener.close();
         done();
       }, 10);
@@ -127,13 +215,16 @@ describe('http client', () => {
         for (let m of measurements) {
           const name = m.id.name;
 
-          if (name === 'http.req.complete') {
+          if (name !== 'ipc.client.call') {
+            assert.fail(m.id.name, 'ipc.client.call', `Unexpected measurement: ${m.id.key}`);
+          } else {
             ++timerCount;
-            assert.equal(m.id.tags.get('status'), 'timeout');
-            assert.equal(m.id.tags.get('statusCode'), 'timeout');
+            assert.equal(m.id.tags.get('ipc.endpoint'), '/json');
+            assert.equal(m.id.tags.get('ipc.result'), 'failure');
+            assert.equal(m.id.tags.get('ipc.status'), 'timeout');
           }
         }
-        assert.equal(timerCount, 4);
+        assert.equal(timerCount, 5);
         listener.close();
         done();
       }, 10);
@@ -155,15 +246,18 @@ describe('http client', () => {
       limit: '8mb'
     }));
 
-    h.postJson('http://foo.example.org/', {foo: 'bar'});
+    h.postJson('http://foo.example.org/not_found', {foo: 'bar'});
     setTimeout(() => {
       const measurements = r.measurements();
       console.log(`Got ${measurements.length} measurements`);
 
       for (let m of measurements) {
-        if (m.id.name === 'http.req.complete') {
-          assert.equal(m.id.tags.get('status'), 'ENOTFOUND');
-          assert.equal(m.id.tags.get('statusCode'), 'ENOTFOUND');
+        if (m.id.name !== 'ipc.client.call') {
+          assert.fail(m.id.name, 'ipc.client.call', `Unexpected measurement: ${m.id.key}`);
+        } else {
+          assert.equal(m.id.tags.get('ipc.result'), 'failure');
+          assert.equal(m.id.tags.get('ipc.status'), 'ENOTFOUND');
+          assert.equal(m.id.tags.get('ipc.endpoint'), '/not_found');
         }
       }
       done();


### PR DESCRIPTION
Switch from the old spectator names, to the new IPC metric names:

https://netflix.github.io/spectator/en/latest/ext/ipc/