### PR TITLE
Add metrics to track measurements sent and dropped

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -41,6 +41,7 @@ class HttpClient {
     };
 
     let attemptNumber = 0;
+
     const metricsHandler = (err, res) => {
       if (err) {
         let error = err.code;

--- a/src/publisher.js
+++ b/src/publisher.js
@@ -19,6 +19,12 @@ class Publisher {
    */
   constructor(registry) {
     this.registry = registry;
+    this.sentMetrics = registry.counter('spectator.measurements', {id: 'sent'});
+    this.invalidMetrics = registry.counter('spectator.measurements',
+      {id: 'dropped', error: 'validation'});
+    this.droppedHttp = registry.counter('spectator.measurements',
+      {id: 'dropped', error: 'http-error'});
+
     this.http = new HttpClient(registry);
   }
 
@@ -113,7 +119,7 @@ class Publisher {
   }
 
   /**
-   * makes http request to spectator and sends accumulated measurements
+   * makes http request to atlas-aggregator with accumulated measurements
    * @private
    * @param {object[]} measurements measurements to be published
    * @param {function(e: Error, res: any): void} [cb = ()=> {}] callback function
@@ -122,9 +128,37 @@ class Publisher {
   _sendMeasurements(measurements, cb = () => {}) {
     const log = this.registry.logger;
     const uri = this.registry.config.uri;
-    log.debug('Sending ' + measurements.length + ' measurements to ' + uri);
+    log.debug(`Sending ${measurements.length} measurements to ${uri}`);
     const payload = this.payloadForMeasurements(measurements);
-    this.http.postJson(uri, payload, cb);
+    const metricsCallback = (err, res) => {
+      const numMeasurements = measurements.length;
+      if (err) {
+        this.droppedHttp.increment(numMeasurements);
+      } else {
+        let sent = 0;
+        let dropped = 0;
+
+        if (res.statusCode === 200) {
+          sent = numMeasurements;
+        } else if (res.statusCode < 500) {
+          const reply = JSON.parse(res.body);
+          if (reply.errorCount) {
+            dropped = reply.errorCount;
+            sent = numMeasurements - dropped;
+          }
+          let errors = reply.message ? [...new Set(reply.message)].join('; ') : 'unknown cause';
+          this.registry.logger.info(
+            `${dropped} measurement(s) dropped due to validation errors: ${errors}`);
+        } else {
+          this.droppedHttp.increment(numMeasurements);
+        }
+        this.invalidMetrics.increment(dropped);
+        this.sentMetrics.increment(sent);
+      }
+      cb(err, res);
+    };
+
+    this.http.postJson(uri, payload, metricsCallback);
     if (typeof log.isLevelEnabled === 'function' && log.isLevelEnabled('trace')) {
       for (const m of measurements) {
         log.trace(`Sent: ${m.id.key}=${m.v}`);

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -9,18 +9,24 @@ const express = require('express');
 const bodyParser = require('body-parser');
 
 describe('http client', () => {
-  it('should post JSON updating a timer', (done) => {
-    const r = new AtlasRegistry();
-    const h = new HttpClient(r);
+
+  function getServer() {
     const server = express();
     server.use(bodyParser.json({
       type: 'application/json',
       limit: '8mb'
     }));
+    return server;
+  }
+
+  it('should post JSON updating a timer', (done) => {
+    const r = new AtlasRegistry();
+    const h = new HttpClient(r);
+    const server = getServer();
 
     const listener = server.listen(() => {
       const port = listener.address().port;
-      console.log('Listening on ' + port);
+      console.log(`Listening on ${port}`);
       h.postJson('http://localhost:' + port + '/foo-endpoint',
         {foo: 'bar'});
     });
@@ -58,15 +64,11 @@ describe('http client', () => {
   it('handle 5xx', (done) => {
     const r = new AtlasRegistry();
     const h = new HttpClient(r);
-    const server = express();
-    server.use(bodyParser.json({
-      type: 'application/json',
-      limit: '8mb'
-    }));
+    const server = getServer();
 
     const listener = server.listen(() => {
       const port = listener.address().port;
-      console.log('Listening on ' + port);
+      console.log(`Listening on ${port}`);
       h.postJson('http://localhost:' + port + '/json503?',
         {foo: 'bar'});
     });
@@ -118,15 +120,11 @@ describe('http client', () => {
   it('handle retries', (done) => {
     const r = new AtlasRegistry();
     const h = new HttpClient(r);
-    const server = express();
-    server.use(bodyParser.json({
-      type: 'application/json',
-      limit: '8mb'
-    }));
+    const server = getServer();
 
     const listener = server.listen(() => {
       const port = listener.address().port;
-      console.log('Listening on ' + port);
+      console.log(`Listening on ${port}`);
       h.postJson('http://localhost:' + port + '/json503?',
         {foo: 'bar'});
     });
@@ -189,15 +187,11 @@ describe('http client', () => {
   it('handle timeout errors', (done) => {
     const r = new AtlasRegistry({timeout: 10}); // 10ms timeout
     const h = new HttpClient(r);
-    const server = express();
-    server.use(bodyParser.json({
-      type: 'application/json',
-      limit: '8mb'
-    }));
+    const server = getServer();
 
     const listener = server.listen(() => {
       const port = listener.address().port;
-      console.log('Listening on ' + port);
+      console.log(`Listening on ${port}`);
       h.postJson('http://localhost:' + port + '/json',
         {foo: 'bar'});
     });
@@ -240,11 +234,6 @@ describe('http client', () => {
   it('handle hostname errors', (done) => {
     const r = new AtlasRegistry();
     const h = new HttpClient(r);
-    const server = express();
-    server.use(bodyParser.json({
-      type: 'application/json',
-      limit: '8mb'
-    }));
 
     h.postJson('http://foo.example.org/not_found', {foo: 'bar'});
     setTimeout(() => {

--- a/test/polled_meter.test.js
+++ b/test/polled_meter.test.js
@@ -6,6 +6,10 @@ const PolledMeter = require('../src/polled_meter');
 const Registry = require('../src/registry');
 
 describe('PolledMeter', () => {
+  function myMeters(r) {
+    return r.meters().filter(m => !m.id.name.startsWith('spectator.'));
+  }
+
   it('monitorValue using name/tags', (done) => {
     const r = new Registry({gaugePollingFrequency: 1, strictMode: true});
     let i = 1;
@@ -13,7 +17,7 @@ describe('PolledMeter', () => {
       {foo: 'bar'}).monitorValue(() => i + 1);
 
     setTimeout(() => {
-      const ms = r.meters();
+      const ms = myMeters(r);
       assert.lengthOf(ms, 1);
       assert.equal(ms[0].get(), 2);
       r.stop();
@@ -29,7 +33,7 @@ describe('PolledMeter', () => {
     x = 42;
 
     setTimeout(() => {
-      const ms = r.meters();
+      const ms = myMeters(r);
       assert.lengthOf(ms, 1);
       assert.equal(ms[0].get(), 42);
       r.stop();
@@ -46,7 +50,7 @@ describe('PolledMeter', () => {
     x = 42;
 
     setTimeout(() => {
-      const ms = r.meters();
+      const ms = myMeters(r);
       assert.lengthOf(ms, 1);
       assert.equal(ms[0].get(), 42 + 43);
       r.stop();
@@ -67,7 +71,7 @@ describe('PolledMeter', () => {
     y = 201;
 
     setTimeout(() => {
-      const ms = r.meters();
+      const ms = myMeters(r);
       assert.lengthOf(ms, 1);
       assert.equal(ms[0].count, 43);
       r.stop();

--- a/test/publisher.test.js
+++ b/test/publisher.test.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const chai = require('chai');
+const assert = chai.assert;
+const AtlasRegistry = require('../src/registry');
+const express = require('express');
+const bodyParser = require('body-parser');
+
+describe('registry publisher', () => {
+
+  function testMeasurements(statusCode, response, assertCallback, done) {
+    const r = new AtlasRegistry({});
+    const server = express();
+    server.use(bodyParser.json({
+      type: 'application/json',
+      limit: '8mb'
+    }));
+
+    const sendMeasurements = () => {
+      const valid1 = r.createId('foo1');
+      const valid2 = r.createId('foo1', {key: 'value'});
+      const invalid = r.createId('name', {'nf.k': 'foo'});
+
+      r.publisher._sendMeasurements([
+        {id: valid1, v: 1.0},
+        {id: valid2, v: 2.0},
+        {id: invalid, v: 3.0}], () => {
+        const ms = r.measurements().filter(m => m.id.name === 'spectator.measurements');
+        assertCallback(ms);
+      });
+    };
+
+    const listener = server.listen(() => {
+      const port = listener.address().port;
+      console.log(`Waiting for measurements using port ${port}`);
+      r.config.uri = `http://localhost:${port}/metrics`;
+      sendMeasurements();
+    });
+
+    server.post('/metrics', (req, res) => {
+      r.logger.trace(`Got measurements payload: ${JSON.stringify(req.body)}`);
+      res.status(statusCode);
+      res.send(JSON.stringify(response));
+      res.end();
+      setTimeout(() => {
+        listener.close();
+        done();
+      }, 10);
+    });
+  }
+
+  it('should generate metrics for valid measurements', (done) => {
+    testMeasurements(200, {ok: 1}, (ms) => {
+      assert.lengthOf(ms, 1);
+      assert.equal(ms[0].id.key, 'spectator.measurements|id=sent|statistic=count');
+      assert.equal(ms[0].v, 3);
+    }, done);
+  });
+
+  it('should generate metrics for partial successes sending measurements', (done) => {
+    const partial = {
+      type:'partial',
+      errorCount:1,
+      message:["invalid key for reserved prefix 'nf.': nf.k"]
+    };
+
+    testMeasurements(202, partial, (ms) => {
+      ms.sort();
+      assert.lengthOf(ms, 2);
+
+      assert.equal(ms[0].id.key, 'spectator.measurements|id=sent|statistic=count');
+      assert.equal(ms[0].v, 2);
+      assert.equal(ms[1].id.key,
+        'spectator.measurements|error=validation|id=dropped|statistic=count');
+      assert.equal(ms[1].v, 1);
+    }, done);
+  });
+
+  it('should generate metrics for all invalid measurements', (done) => {
+    const invalidReq = {
+      type:'error',
+      errorCount:3,
+      message:["invalid key for reserved prefix 'nf.': nf.nodex",
+        "invalid key for reserved prefix 'nf.': nf.nodex",
+        "invalid key for reserved prefix 'nf.': nf.nodex"]};
+
+    testMeasurements(400, invalidReq, (ms) => {
+      assert.lengthOf(ms, 1);
+
+      assert.equal(ms[0].id.key,
+        'spectator.measurements|error=validation|id=dropped|statistic=count');
+      assert.equal(ms[0].v, 3);
+    }, done);
+  });
+
+  it('should generate metrics for server errors', (done) => {
+    testMeasurements(500, {}, (ms) => {
+      assert.lengthOf(ms, 1);
+      assert.equal(ms[0].id.key,
+        'spectator.measurements|error=http-error|id=dropped|statistic=count');
+      assert.equal(ms[0].v, 3);
+    }, done);
+  });
+});


### PR DESCRIPTION
This adds metrics to track the number of measurements sent and dropped
due to validation or network errors.

`spectator.measurements`:

  * `id=sent`
  * `id=dropped` `error=validation`
  * `id=dropped` `error=http-error`

Using these new metrics our users could detect sudden behavior changes
as they test new releases, and their effect on metrics produced.