### PR TITLE
Fix tag name in successful ipc calls

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -10,12 +10,6 @@ class HttpClient {
    */
   constructor(registry) {
     this.registry = registry;
-
-    this.baseId = registry.createId('http.req.complete', {
-      method: 'POST',
-      mode: 'http-client',
-      client: 'spectator-js'
-    });
   }
 
   /**

--- a/src/log_entry.js
+++ b/src/log_entry.js
@@ -70,7 +70,7 @@ class LogEntry {
    */
   setSuccess() {
     const ipcSuccess = 'success';
-    this.id = this.id.withTag('ipc.result', ipcSuccess).withTag('ipc.result', ipcSuccess);
+    this.id = this.id.withTag('ipc.result', ipcSuccess).withTag('ipc.status', ipcSuccess);
   }
 }
 


### PR DESCRIPTION
Plus remove unused ID in our http client now that we are using log_entry