### PR TITLE
Add a hook for tweaking https connect options

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -34,6 +34,8 @@ class HttpClient {
       response_timeout: timeout
     };
 
+    this.registry.config.connectOptions(options);
+
     let attemptNumber = 0;
 
     const metricsHandler = (err, res) => {

--- a/src/registry.js
+++ b/src/registry.js
@@ -46,6 +46,9 @@ class AtlasRegistry {
     if (!this.config.isEnabled) {
       this.config.isEnabled = () => true;
     }
+    if (!this.config.connectOptions) {
+      this.config.connectOptions = (options) => options;
+    }
     if (!this.config.batchSize) {
       this.config.batchSize = 10000;
     }

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -2,7 +2,6 @@
 
 const chai = require('chai');
 const assert = chai.assert;
-
 const AtlasRegistry = require('../src/registry');
 const HttpClient = require('../src/http');
 const express = require('express');


### PR DESCRIPTION
Support a new config option: `connectOptions` a function that will be
called before making http(s) requests allowing the user to add
keys/certs, etc.