### PR TITLE
Ignore broken replies from the server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Daniel Muino <dmuino@gmail.com>",
   "main": "src/index.js",
   "homepage": "https://github.org/Netflix/spectator-js",

--- a/src/publisher.js
+++ b/src/publisher.js
@@ -142,7 +142,13 @@ class Publisher {
         if (res.statusCode === 200) {
           sent = numMeasurements;
         } else if (res.statusCode < 500) {
-          const reply = JSON.parse(res.body);
+          let reply;
+          try {
+            reply = JSON.parse(res.body);
+          } catch (e) {
+            this.registry.logger.info(`Unable to parse response from server: ${res.body}`);
+            reply = {};
+          }
           if (reply.errorCount) {
             dropped = reply.errorCount;
             sent = numMeasurements - dropped;


### PR DESCRIPTION
If the server sends us a response that cannot be parsed as JSON ignore
it. Previously we would crash.