### PR TITLE
Http response body can be an object

### DIFF
--- a/src/publisher.js
+++ b/src/publisher.js
@@ -143,7 +143,7 @@ class Publisher {
           sent = numMeasurements;
         } else if (res.statusCode < 500) {
           let reply;
-          if (typeof(res.body) === 'object') {
+          if (typeof (res.body) === 'object') {
             reply = res.body;
           } else {
             try {

--- a/src/publisher.js
+++ b/src/publisher.js
@@ -143,11 +143,15 @@ class Publisher {
           sent = numMeasurements;
         } else if (res.statusCode < 500) {
           let reply;
-          try {
-            reply = JSON.parse(res.body);
-          } catch (e) {
-            this.registry.logger.info(`Unable to parse response from server: ${res.body}`);
-            reply = {};
+          if (typeof(res.body) === 'object') {
+            reply = res.body;
+          } else {
+            try {
+              reply = JSON.parse(res.body);
+            } catch (e) {
+              this.registry.logger.info(`Unable to parse response from server: ${res.body}`);
+              reply = {};
+            }
           }
           if (reply.errorCount) {
             dropped = reply.errorCount;
@@ -157,8 +161,9 @@ class Publisher {
               `${dropped} measurement(s) dropped due to validation errors: ${errors}`);
           } else {
             // Either a different cause for a 400 error, or a different 4xx error
+            const body = JSON.stringify(reply);
             this.registry.logger.info(
-              `${numMeasurements} measurement(s) dropped. Http status: ${res.statusCode}`
+              `${numMeasurements} measurement(s) dropped. Http status: ${res.statusCode} ${body}`
             );
             this.droppedOther.increment(numMeasurements);
           }

--- a/test/publisher.test.js
+++ b/test/publisher.test.js
@@ -126,4 +126,20 @@ describe('registry publisher', () => {
       assert.equal(ms[0].v, 3);
     }, done, true);
   });
+
+  it('should handle large responses', (done) => {
+    const largeResponse = {};
+    largeResponse.errorCount = 1000;
+    largeResponse.message = [];
+    const largeMessage = 'value too large: ' + 'foo'.repeat(10000);
+    for (let i = 0; i < largeResponse.errorCount; ++i) {
+      largeResponse.message.push(largeMessage);
+    }
+    testMeasurements(400, largeResponse, (ms) => {
+      assert.lengthOf(ms, 1);
+      assert.equal(ms[0].id.key,
+        'spectator.measurements|error=validation|id=dropped|statistic=count');
+      assert.equal(ms[0].v, 1000);
+    }, done);
+  });
 });

--- a/test/publisher.test.js
+++ b/test/publisher.test.js
@@ -126,20 +126,4 @@ describe('registry publisher', () => {
       assert.equal(ms[0].v, 3);
     }, done, true);
   });
-
-  it('should handle large responses', (done) => {
-    const largeResponse = {};
-    largeResponse.errorCount = 1000;
-    largeResponse.message = [];
-    const largeMessage = 'value too large: ' + 'foo'.repeat(10000);
-    for (let i = 0; i < largeResponse.errorCount; ++i) {
-      largeResponse.message.push(largeMessage);
-    }
-    testMeasurements(400, largeResponse, (ms) => {
-      assert.lengthOf(ms, 1);
-      assert.equal(ms[0].id.key,
-        'spectator.measurements|error=validation|id=dropped|statistic=count');
-      assert.equal(ms[0].v, 1000);
-    }, done);
-  });
 });


### PR DESCRIPTION
It seems `needle` is now parsing the response body and returning it as
an `object`. Handle the case where it's an object or the old behavior
where it's returned as a string