### PR TITLE
Only publish using node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ after_success:
 deploy:
   on: 
     tags: true
+    node_js: '10'
   provider: npm
   tag: next
   email: dmuino@gmail.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "author": "Daniel Muino <dmuino@gmail.com>",
   "main": "src/index.js",
   "types": "src/index.d.ts",


### PR DESCRIPTION
Travis attempts to publish the module with the first version that
finishes building but now we need to have at least node 10 since the
version of npm bundled with node 6 does not include a prepare script.