### PR TITLE
Avoid using rimraf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5217,31 +5217,6 @@
       "resolved": "https://artifacts.netflix.com/api/npm/npm-netflix/revalidator/-/revalidator-0.1.8.tgz",
       "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
       "dev": true
-    },
-    "rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.3"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
-      }
     },
     "run-async": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "author": "Daniel Muino <dmuino@gmail.com>",
   "main": "src/index.js",
   "types": "src/index.d.ts",
@@ -22,12 +22,11 @@
     "istanbul": "^0.4.5",
     "jscs": "^3.0.7",
     "mocha": "^5.2.0",
-    "rimraf": "^3.0.2",
     "travis-deploy-once": "^4.4.1",
     "tsd": "^0.11.0"
   },
   "scripts": {
-    "clean": "node_modules/rimraf/bin.js ./src/*.d.ts",
+    "clean": "rm -f ./src/*.d.ts",
     "copy": "cp -rf ./types/* ./src",
     "prepare": "npm run clean && npm run copy",
     "test": "npm run test:unit && npm run test:types",


### PR DESCRIPTION
It causes issues for the travis deploy phase, which does not run `npm
install` and therefore `rimraf` is not present