### PR TITLE
fix: downgrade timeout error to debug log

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -44,7 +44,7 @@ class HttpClient {
 
         if (error === 'ECONNRESET') {
           logEntry.setError('timeout');
-          log.error(`Timeout POSTing metrics to ${endpoint}`);
+          log.debug(`Timeout POSTing metrics to ${endpoint}`);
         } else {
           log.error(`problem with request: ${err.message}`);
           logEntry.setError(err.code.toString());


### PR DESCRIPTION
This log is VERY commonly hit and since it is retried it is not useful to users.  Downgrading to `debug` will easily let us turn it back on if we need to debug.

Ideally libraries will *never* log directly but instead expose interfaces for consumers to log off specific events.  While it would be a breaking change with low impact right now I would not recommend making this change now, but if you cut a major in the future I would look at surfacing these errors and warnings as events on the main registry interface. That way platforms like NQ can still log valuable events but will have more control over it without having to PR changes like this to the lib.