### PR TITLE
fix: pre-allocate meters array size

### DIFF
--- a/src/registry.js
+++ b/src/registry.js
@@ -399,12 +399,20 @@ class AtlasRegistry {
    *   by our registered meters.
    */
   measurements() {
-    let a = [];
+    // meter.measure() returns an array of up to 4 items,
+    // so pre-allocate the max size and trim down at the end
+    let a = new Array(this.metersMap.size * 4);
+    let len = 0;
 
     for (let meter of this.metersMap.values()) {
-      Array.prototype.push.apply(a, meter.measure());
+      const measures = meter.measure();
+      for (let m of measures) {
+        a[len] = m;
+        len++;
+      }
     }
-    return a;
+    // Slice off any trailing empty values
+    return Array.prototype.slice.call(a, 0, len);
   }
 
   /**


### PR DESCRIPTION
As we were investigating the recent increase in heap allocation after bumping to latest for this lib, it came down to this change: https://github.com/Netflix/spectator-js/pull/34

I was thinking that maybe pushing on the array (changing it's size) caused v8 to over allocate for the array, even if it does not end up getting used.  I thought maybe this might help, and if nothing else it should not hurt.  Additionally, I was thinking we could change from `.push` to index setting, but with performance things it can be surprising, so I figured I would start with this PR to change one small thing at a time.

Thoughts?