### PR TITLE
install dependencies for github actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,12 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10, 12, 14, 16]
+        node-version: [10, 12, 14]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install Dependencies
+        run: npm install
       - name: Make
         run: make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10, 12, 14, 16]
+        node-version: [10, 12, 14]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install Dependencies
+        run: npm install
       - name: Make
         run: make

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -11,12 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10, 12, 14, 16]
+        node-version: [10, 12, 14]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install Dependencies
+        run: npm install
       - name: Make
         run: make


### PR DESCRIPTION
Also, remove the node-16 version from the test matrix, because it hangs
during the npm install step with no output. Not sure how to fix this, so
we'll just skip it for now.
