### PR TITLE
batch increment for BucketCounter

### DIFF
--- a/src/bucket_counter.js
+++ b/src/bucket_counter.js
@@ -30,6 +30,19 @@ class BucketCounter {
   record(amount) {
     this._counter(this.bucketFunction(amount)).increment();
   }
+
+  /**
+   * Update the counter associated with the amount by {@code n}.
+   *
+   * @param {number} amount
+   *     Amount to use for determining the bucket.
+   * @param {number} n
+   *     The delta to apply to the counter.
+   * @returns {undefined}
+   */
+  increment(amount, n) {
+    this._counter(this.bucketFunction(amount)).increment(n);
+  }
 }
 
 module.exports = BucketCounter;

--- a/test/bucket_counter.test.js
+++ b/test/bucket_counter.test.js
@@ -35,4 +35,19 @@ describe('Bucket Counters', () => {
     assert.lengthOf(meters, 2);
     assert.equal(sum(meters), 3);
   });
+
+  it('increment', () => {
+    const r = new Registry();
+    const c = BucketCounter.get(r, r.createId('test'), BucketFunctions.latency(4, 's'));
+
+    c.record(3750 * 1e6);
+    let meters = filter(r.meters(), 'test');
+    assert.lengthOf(meters, 1);
+    assert.equal(sum(meters), 1);
+
+    c.increment(3750 * 1e6, 5);
+    meters = filter(r.meters(), 'test');
+    assert.lengthOf(meters, 1);
+    assert.equal(sum(meters), 6);
+  });
 });


### PR DESCRIPTION
Add `increment` method to BucketCounter to allow for
batch increments of the same amount. Consistent with
interface for Java implementation (Netflix/spectator#950).