### PR TITLE
Update types for hrtime to match Node.process

### DIFF
--- a/types/registry.d.ts
+++ b/types/registry.d.ts
@@ -41,7 +41,7 @@ declare class Registry {
   stop(cb?: (e: Error, res: any) => void): void;
   measurements(): Measurement[];
   meters(): (Counter | DistributionSummary | Gauge | Timer)[];
-  hrtime(time: [number, number]): [number, number];
+  hrtime(time?: [number, number]): [number, number];
 }
 
 export = Registry;


### PR DESCRIPTION
Current typings for hrtime require an argument. However, the implementation actually does not.

See other open source hrtime typings:
https://sourcegraph.com/github.com/DefinitelyTyped/DefinitelyTyped/-/blob/types/node/process.d.ts?L118:13