### PR TITLE
adjust timer record method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Netflix/spectator-js",
   "author": "Netflix Telemetry Engineering <netflix-atlas@googlegroups.com>",

--- a/src/meter/timer.ts
+++ b/src/meter/timer.ts
@@ -11,9 +11,28 @@ export class Timer extends Meter {
         super(id, writer, "t");
     }
 
-    record(seconds: number = 1): Promise<void> {
-        if (seconds >= 0) {
-            const line = `${this._meter_type_symbol}:${this._id.spectatord_id}:${seconds}`
+    /**
+     * @param {number|number[]} seconds
+     *     Number of seconds, which may be fractional, or an array of two numbers [seconds, nanoseconds],
+     *     which is the return value from process.hrtime(), and serves as a convenient means of recording
+     *     latency durations.
+     *
+     *     start = process.hrtime();
+     *     // do work
+     *     registry.timer("eventLatency").record(process.hrtime(start));
+     *
+     */
+    record(seconds: number | number[]): Promise<void> {
+        let elapsed: number;
+
+        if (seconds instanceof Array) {
+            elapsed = seconds[0] + (seconds[1] / 1e9);
+        } else {
+            elapsed = seconds;
+        }
+
+        if (elapsed >= 0) {
+            const line = `${this._meter_type_symbol}:${this._id.spectatord_id}:${elapsed}`;
             return this._writer.write(line);
         } else {
             return new Promise((resolve: (value: void | PromiseLike<void>) => void): void => {

--- a/test/meter/timer.test.ts
+++ b/test/meter/timer.test.ts
@@ -28,4 +28,28 @@ describe("Timer Tests", (): void => {
         t.record(0);
         assert.equal("t:timer:0", writer.last_line());
     });
+
+    it("record latency from hrtime", (): void => {
+        let nanos: number = 0;
+        let round: number = 1;
+        const f: NodeJS.HRTime = process.hrtime;
+        Object.defineProperty(process, "hrtime", {
+            get(): () => [number, number] {
+                return (): [number, number] => {
+                    nanos += round * 1e6;  // 1ms lag first time, 2ms second time, etc.
+                    ++round;
+                    return [0, nanos];
+                };
+            }
+        });
+
+        const start: [number, number] = process.hrtime();
+
+        const t = new Timer(tid, new MemoryWriter());
+        const writer = t.writer() as MemoryWriter;
+        t.record(process.hrtime(start));  // two calls to hrtime = 1ms + 2ms = 3ms
+        assert.equal("t:timer:0.003", writer.last_line());
+
+        Object.defineProperty(process, "hrtime", f);
+    });
 });


### PR DESCRIPTION
Restore the ability to pass process.hrtime() directly to the record method, because this is the simplest way to record latency durations.