### PR TITLE
adjust percentile timer record method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Netflix/spectator-js",
   "author": "Netflix Telemetry Engineering <netflix-atlas@googlegroups.com>",

--- a/src/meter/percentile_timer.ts
+++ b/src/meter/percentile_timer.ts
@@ -17,9 +17,28 @@ export class PercentileTimer extends Meter {
         super(id, writer, "T");
     }
 
-    record(seconds: number): Promise<void> {
-        if (seconds >= 0) {
-            const line = `${this._meter_type_symbol}:${this._id.spectatord_id}:${seconds}`
+    /**
+     * @param {number|number[]} seconds
+     *     Number of seconds, which may be fractional, or an array of two numbers [seconds, nanoseconds],
+     *     which is the return value from process.hrtime(), and serves as a convenient means of recording
+     *     latency durations.
+     *
+     *     start = process.hrtime();
+     *     // do work
+     *     registry.pct_timer("eventLatency").record(process.hrtime(start));
+     *
+     */
+    record(seconds: number | number[]): Promise<void> {
+        let elapsed: number;
+
+        if (seconds instanceof Array) {
+            elapsed = seconds[0] + (seconds[1] / 1e9);
+        } else {
+            elapsed = seconds;
+        }
+
+        if (elapsed >= 0) {
+            const line = `${this._meter_type_symbol}:${this._id.spectatord_id}:${elapsed}`;
             return this._writer.write(line);
         } else {
             return new Promise((resolve: (value: void | PromiseLike<void>) => void): void => {


### PR DESCRIPTION
Add the ability to pass process.hrtime() directly to the record method, because this is the simplest way to record latency durations. This keeps the usage similar to timers.