### PR TITLE
remove references to unix domain sockets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Netflix/spectator-js",
   "author": "Netflix Telemetry Engineering <netflix-atlas@googlegroups.com>",

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,12 +18,23 @@ export class Config {
      *   * `stderr` - Write metrics to standard error.
      *   * `stdout` - Write metrics to standard output.
      *   * `udp`    - Write metrics to the default spectatord UDP port. This is the default value.
-     *   * `unix`   - Write metrics to the default spectatord Unix Domain Socket. Useful for high-volume scenarios.
-     *   * `file:///path/to/file` - Write metrics to a file or a Unix Domain Socket.
+     *   * `file:///path/to/file` - Write metrics to a file.
      *   * `udp://host:port`      - Write metrics to a UDP socket.
      *
      * The output location can be overridden by configuring an environment variable SPECTATOR_OUTPUT_LOCATION
      * with one of the values listed above. Overriding the output location may be useful for integration testing.
+     *
+     * Unix Domain Sockets are not supported in this library, because Node.js removed the `unix_dgram` package
+     * from the standard library in 2011, as a part of portability concerns for Windows.
+     *
+     * https://github.com/nodejs/node/issues/29339
+     *
+     * There is a third-party `unix-dgram` library, but it contains C++ source code, which complicates the build,
+     * and it introduces synchronous calls in the context of callbacks. We want this library to be as low-friction
+     * as possible, so we will not adopt this package. If you need UDS support, use the C++, Go, or Python libraries
+     * instead.
+     *
+     * https://github.com/bnoordhuis/node-unix-dgram
      */
 
     location: string;

--- a/src/writer/file_writer.ts
+++ b/src/writer/file_writer.ts
@@ -5,8 +5,7 @@ import {fileURLToPath} from "node:url";
 
 export class FileWriter extends Writer {
     /**
-     * Writer that outputs data to a file descriptor, which can be stdout, stderr, a unix domain
-     * socket, or a regular file.
+     * Writer that outputs data to a file descriptor, which can be stdout, stderr, or a regular file.
      */
 
     private readonly _location: string;

--- a/src/writer/new_writer.ts
+++ b/src/writer/new_writer.ts
@@ -10,7 +10,7 @@ import {StdoutWriter} from "./stdout_writer.js";
 export type WriterUnion = FileWriter | MemoryWriter | NoopWriter | StderrWriter | StdoutWriter | UdpWriter;
 
 export function is_valid_output_location(location: string): boolean {
-    return ["none", "memory", "stderr", "stdout", "udp", "unix"].includes(location) ||
+    return ["none", "memory", "stderr", "stdout", "udp"].includes(location) ||
         location.startsWith("file://") ||
         location.startsWith("udp://");
 }
@@ -38,9 +38,6 @@ export function new_writer(location: string, logger?: Logger): WriterUnion {
         } else {
             writer = new UdpWriter(location, parsed.hostname, Number(parsed.port), logger);
         }
-    } else if (location == "unix") {
-        location = "file:///run/spectatord/spectatord.unix";
-        writer = logger == undefined ? new FileWriter(location) : new FileWriter(location, logger);
     } else if (location.startsWith("file://")) {
         writer = logger == undefined ? new FileWriter(location) : new FileWriter(location, logger);
     } else if (location.startsWith("udp://")) {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -63,7 +63,6 @@ describe("Config Tests", (): void => {
         assert.equal("stderr", get_location("stderr"));
         assert.equal("stdout", get_location("stdout"));
         assert.equal("udp", get_location("udp"));
-        assert.equal("unix", get_location("unix"));
         assert.equal("file://", get_location("file://"));
         assert.equal("udp://", get_location("udp://"));
     });


### PR DESCRIPTION
The `unix_gram` module was removed from the standard library in 2011, for Windows portability reasons, so this library will not support Unix Domain Sockets.

https://github.com/nodejs/node/issues/29339

There is a third-party library `unix-dgram`, which offers this functionality, but it introduces some complications, and we want this library to be as low- friction as possible. Thus, we will not adopt this module.

https://github.com/bnoordhuis/node-unix-dgram

This state of affairs is similar to the Java thin-client, where the JVM does not support Unix Domain Sockets until 16+:

https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/net/UnixDomainSocketAddress.html).