### PR TITLE
Performance Improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator",
-  "version": "3.0.18",
+  "version": "3.1.0-rc.1",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Netflix/spectator-js",
   "author": "Netflix Telemetry Engineering <netflix-atlas@googlegroups.com>",

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -18,34 +18,10 @@ export type Logger = {
 };
 
 export function get_logger(level_name?: string): Logger {
-    let level_filter: number;
-    if (level_name == undefined || !(level_name in levels)) {
-        level_filter = levels.info;
-    } else {
-        level_filter = levels[level_name];
-    }
+    const level_filter = (level_name && level_name in levels) ? levels[level_name] : levels.info;
 
-    const logger: Logger = {
-        is_level_enabled: (name: string): boolean => levels[name] >= level_filter,
-        trace: function (): void {
-            throw new Error("Function not implemented.");
-        },
-        debug: function (): void {
-            throw new Error("Function not implemented.");
-        },
-        info: function (): void {
-            throw new Error("Function not implemented.");
-        },
-        warn: function (): void {
-            throw new Error("Function not implemented.");
-        },
-        error: function (): void {
-            throw new Error("Function not implemented.");
-        },
-        fatal: function (): void {
-            throw new Error("Function not implemented.");
-        }
-    };
+    const logger = {} as Logger;
+    logger.is_level_enabled = (name: string): boolean => levels[name] >= level_filter;
 
     for (const name in levels) {
         if (levels[name] < level_filter) {

--- a/src/meter/counter.ts
+++ b/src/meter/counter.ts
@@ -20,10 +20,7 @@ export class Counter extends Meter {
         if (amount > 0) {
             const line = `${this._meter_type_symbol}:${this._id.spectatord_id}:${amount}`
             return this._writer.write(line);
-        } else {
-            return new Promise((resolve: (value: void | PromiseLike<void>) => void): void => {
-                resolve();
-            });
         }
+        return Promise.resolve();
     }
 }

--- a/src/meter/dist_summary.ts
+++ b/src/meter/dist_summary.ts
@@ -18,10 +18,7 @@ export class DistributionSummary extends Meter {
         if (amount >= 0) {
             const line = `${this._meter_type_symbol}:${this._id.spectatord_id}:${amount}`
             return this._writer.write(line);
-        } else {
-            return new Promise((resolve: (value: void | PromiseLike<void>) => void): void => {
-                resolve();
-            });
         }
+        return Promise.resolve();
     }
 }

--- a/src/meter/id.ts
+++ b/src/meter/id.ts
@@ -8,16 +8,12 @@ export function tags_toString(tags: Tags | undefined): string {
         return "{}"
     }
 
-    let result: string = "{";
-
-    if (Object.entries(tags).length > 0) {
-        Object.entries(tags).forEach(([k, v]: [string, string]): void => {
-            result += `'${k}': '${v}', `;
-        });
-        result = result.slice(0, -2);
+    const entries = Object.entries(tags);
+    if (entries.length === 0) {
+        return "{}";
     }
 
-    return result + "}";
+    return "{" + entries.map(([k, v]) => `'${k}': '${v}'`).join(", ") + "}";
 }
 
 export class Id {
@@ -27,7 +23,7 @@ export class Id {
      * ensure that any extra common tags are properly applied to the Meter.
      */
 
-    private INVALID_CHARS: RegExp = new RegExp(/[^-._A-Za-z0-9~^]/g);
+    private static readonly INVALID_CHARS = /[^-._A-Za-z0-9~^]/g;
 
     private readonly _logger: Logger;
     private readonly _name: string;
@@ -38,19 +34,11 @@ export class Id {
 
     constructor(name: string, tags?: Tags, logger?: Logger) {
         // initialization order in this constructor matters, for logging and testing purposes
-        if (logger == undefined) {
-            this._logger = get_logger();
-        } else {
-            this._logger = logger;
-        }
+        this._logger = logger ?? get_logger();
 
         this._name = name;
 
-        if (tags == undefined) {
-            this._tags = {}
-        } else {
-            this._tags = this.validate_tags_for_id(tags);
-        }
+        this._tags = tags ? this.validate_tags_for_id(tags) : {};
 
         this.spectatord_id = this.to_spectatord_id(this._name, this._tags);
     }
@@ -68,7 +56,7 @@ export class Id {
     }
 
     private replace_invalid_chars(s: string): string {
-        return s.replace(this.INVALID_CHARS, "_");
+        return s.replace(Id.INVALID_CHARS, "_");
     }
 
     private to_spectatord_id(name: string, tags?: Tags): string {

--- a/src/meter/percentile_dist_summary.ts
+++ b/src/meter/percentile_dist_summary.ts
@@ -23,10 +23,7 @@ export class PercentileDistributionSummary extends Meter {
         if (amount >= 0) {
             const line = `${this._meter_type_symbol}:${this._id.spectatord_id}:${amount}`
             return this._writer.write(line);
-        } else {
-            return new Promise((resolve: (value: void | PromiseLike<void>) => void): void => {
-                resolve();
-            });
         }
+        return Promise.resolve();
     }
 }

--- a/src/meter/percentile_timer.ts
+++ b/src/meter/percentile_timer.ts
@@ -48,10 +48,7 @@ export class PercentileTimer extends Meter {
         if (elapsed >= 0) {
             const line = `${this._meter_type_symbol}:${this._id.spectatord_id}:${elapsed}`;
             return this._writer.write(line);
-        } else {
-            return new Promise((resolve: (value: void | PromiseLike<void>) => void): void => {
-                resolve();
-            });
         }
+        return Promise.resolve();
     }
 }

--- a/src/meter/timer.ts
+++ b/src/meter/timer.ts
@@ -43,10 +43,7 @@ export class Timer extends Meter {
         if (elapsed >= 0) {
             const line = `${this._meter_type_symbol}:${this._id.spectatord_id}:${elapsed}`;
             return this._writer.write(line);
-        } else {
-            return new Promise((resolve: (value: void | PromiseLike<void>) => void): void => {
-                resolve();
-            });
         }
+        return Promise.resolve();
     }
 }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -51,9 +51,7 @@ export class Registry {
             if (error instanceof Error) {
                 this.logger.error(`Error closing Registry Writer: ${error.message}`);
             }
-            return new Promise((_: (value: void | PromiseLike<void>) => void, reject: (reason?: any) => void): void => {
-                reject(error);
-            });
+            return Promise.reject(error);
         }
     }
 
@@ -71,37 +69,33 @@ export class Registry {
         return new_meter_id;
     }
 
-    age_gauge(name: string, tags: Tags = {}): AgeGauge {
-        const id = this.new_id(name, tags);
+    private create<T>(MeterClass: new (id: Id, writer: WriterUnion) => T, id: Id): T {
         const writer = id.invalid ? this._noop_writer : this._writer;
-        return new AgeGauge(id, writer);
+        return new MeterClass(id, writer);
+    }
+
+    age_gauge(name: string, tags: Tags = {}): AgeGauge {
+        return this.create(AgeGauge, this.new_id(name, tags));
     }
 
     age_gauge_with_id(id: Id): AgeGauge {
-        const writer = id.invalid ? this._noop_writer : this._writer;
-        return new AgeGauge(id, writer);
+        return this.create(AgeGauge, id);
     }
 
     counter(name: string, tags: Tags = {}): Counter {
-        const id = this.new_id(name, tags);
-        const writer = id.invalid ? this._noop_writer : this._writer;
-        return new Counter(id, writer);
+        return this.create(Counter, this.new_id(name, tags));
     }
 
     counter_with_id(id: Id): Counter {
-        const writer = id.invalid ? this._noop_writer : this._writer;
-        return new Counter(id, writer);
+        return this.create(Counter, id);
     }
 
     distribution_summary(name: string, tags: Tags = {}): DistributionSummary {
-        const id = this.new_id(name, tags);
-        const writer = id.invalid ? this._noop_writer : this._writer;
-        return new DistributionSummary(id, writer);
+        return this.create(DistributionSummary, this.new_id(name, tags));
     }
 
     distribution_summary_with_id(id: Id): DistributionSummary {
-        const writer = id.invalid ? this._noop_writer : this._writer;
-        return new DistributionSummary(id, writer);
+        return this.create(DistributionSummary, id);
     }
 
     gauge(name: string, tags: Tags = {}, ttl_seconds?: number): Gauge {
@@ -116,68 +110,50 @@ export class Registry {
     }
 
     max_gauge(name: string, tags: Tags = {}): MaxGauge {
-        const id = this.new_id(name, tags);
-        const writer = id.invalid ? this._noop_writer : this._writer;
-        return new MaxGauge(id, writer);
+        return this.create(MaxGauge, this.new_id(name, tags));
     }
 
     max_gauge_with_id(id: Id): MaxGauge {
-        const writer = id.invalid ? this._noop_writer : this._writer;
-        return new MaxGauge(id, writer);
+        return this.create(MaxGauge, id);
     }
 
     monotonic_counter(name: string, tags: Tags = {}): MonotonicCounter {
-        const id = this.new_id(name, tags);
-        const writer = id.invalid ? this._noop_writer : this._writer;
-        return new MonotonicCounter(id, writer);
+        return this.create(MonotonicCounter, this.new_id(name, tags));
     }
 
     monotonic_counter_with_id(id: Id): MonotonicCounter {
-        const writer = id.invalid ? this._noop_writer : this._writer;
-        return new MonotonicCounter(id, writer);
+        return this.create(MonotonicCounter, id);
     }
 
     monotonic_counter_uint(name: string, tags: Tags = {}): MonotonicCounterUint {
-        const id = this.new_id(name, tags);
-        const writer = id.invalid ? this._noop_writer : this._writer;
-        return new MonotonicCounterUint(id, writer);
+        return this.create(MonotonicCounterUint, this.new_id(name, tags));
     }
 
     monotonic_counter_uint_with_id(id: Id): MonotonicCounterUint {
-        const writer = id.invalid ? this._noop_writer : this._writer;
-        return new MonotonicCounterUint(id, writer);
+        return this.create(MonotonicCounterUint, id);
     }
 
     pct_distribution_summary(name: string, tags: Tags = {}): PercentileDistributionSummary {
-        const id = this.new_id(name, tags);
-        const writer = id.invalid ? this._noop_writer : this._writer;
-        return new PercentileDistributionSummary(id, writer);
+        return this.create(PercentileDistributionSummary, this.new_id(name, tags));
     }
 
     pct_distribution_summary_with_id(id: Id): PercentileDistributionSummary {
-        const writer = id.invalid ? this._noop_writer : this._writer;
-        return new PercentileDistributionSummary(id, writer);
+        return this.create(PercentileDistributionSummary, id);
     }
 
     pct_timer(name: string, tags: Tags = {}): PercentileTimer {
-        const id = this.new_id(name, tags);
-        const writer = id.invalid ? this._noop_writer : this._writer;
-        return new PercentileTimer(id, writer);
+        return this.create(PercentileTimer, this.new_id(name, tags));
     }
 
     pct_timer_with_id(id: Id): PercentileTimer {
-        const writer = id.invalid ? this._noop_writer : this._writer;
-        return new PercentileTimer(id, writer);
+        return this.create(PercentileTimer, id);
     }
 
     timer(name: string, tags: Tags = {}): Timer {
-        const id = this.new_id(name, tags);
-        const writer = id.invalid ? this._noop_writer : this._writer;
-        return new Timer(id, writer);
+        return this.create(Timer, this.new_id(name, tags));
     }
 
     timer_with_id(id: Id): Timer {
-        const writer = id.invalid ? this._noop_writer : this._writer;
-        return new Timer(id, writer);
+        return this.create(Timer, id);
     }
 }

--- a/src/writer/new_writer.ts
+++ b/src/writer/new_writer.ts
@@ -35,16 +35,14 @@ export function new_writer(location: string, logger?: Logger): WriterUnion {
         return new StdoutWriter(log);
     }
     if (location == "udp") {
-        location = "udp://127.0.0.1:1234"
-        const parsed = new URL(location);
-        return new UdpWriter(location, parsed.hostname, Number(parsed.port), log);
+        location = "udp://127.0.0.1:1234";
     }
     if (location.startsWith("file://")) {
         return new FileWriter(location, log);
     }
     if (location.startsWith("udp://")) {
         const parsed = new URL(location);
-        // convert IPv6 loop-back address from [::1] to ::1, so it works with the socket api
+        // convert IPv6 bracket notation [::1] to ::1 for the socket api
         const hostname = parsed.hostname.replace("[::1]", "::1");
         return new UdpWriter(location, hostname, Number(parsed.port), log);
     }

--- a/src/writer/new_writer.ts
+++ b/src/writer/new_writer.ts
@@ -24,19 +24,25 @@ export function new_writer(location: string, logger?: Logger): WriterUnion {
 
     if (location == "none") {
         return new NoopWriter(log);
-    } else if (location == "memory") {
+    }
+    if (location == "memory") {
         return new MemoryWriter(log);
-    } else if (location == "stderr") {
+    }
+    if (location == "stderr") {
         return new StderrWriter(log);
-    } else if (location == "stdout") {
+    }
+    if (location == "stdout") {
         return new StdoutWriter(log);
-    } else if (location == "udp") {
+    }
+    if (location == "udp") {
         location = "udp://127.0.0.1:1234"
         const parsed = new URL(location);
         return new UdpWriter(location, parsed.hostname, Number(parsed.port), log);
-    } else if (location.startsWith("file://")) {
+    }
+    if (location.startsWith("file://")) {
         return new FileWriter(location, log);
-    } else if (location.startsWith("udp://")) {
+    }
+    if (location.startsWith("udp://")) {
         const parsed = new URL(location);
         // convert IPv6 loop-back address from [::1] to ::1, so it works with the socket api
         const hostname = parsed.hostname.replace("[::1]", "::1");

--- a/src/writer/new_writer.ts
+++ b/src/writer/new_writer.ts
@@ -1,4 +1,4 @@
-import {Logger} from "../logger/logger.js";
+import {get_logger, Logger} from "../logger/logger.js";
 import {NoopWriter} from "./noop_writer.js";
 import {MemoryWriter} from "./memory_writer.js";
 import {FileWriter} from "./file_writer.js";
@@ -20,38 +20,28 @@ export function new_writer(location: string, logger?: Logger): WriterUnion {
      * Create a new Writer based on an output location.
      */
 
-    let writer: WriterUnion;
+    const log = logger ?? get_logger();
 
     if (location == "none") {
-        writer = logger == undefined ? new NoopWriter() : new NoopWriter(logger);
+        return new NoopWriter(log);
     } else if (location == "memory") {
-        writer = logger == undefined ? new MemoryWriter() : new MemoryWriter(logger);
+        return new MemoryWriter(log);
     } else if (location == "stderr") {
-        writer = logger == undefined ? new StderrWriter() : new StderrWriter(logger);
+        return new StderrWriter(log);
     } else if (location == "stdout") {
-        writer = logger == undefined ? new StdoutWriter() : new StdoutWriter(logger);
+        return new StdoutWriter(log);
     } else if (location == "udp") {
         location = "udp://127.0.0.1:1234"
-        const parsed: URL = new URL(location)
-        if (logger == undefined) {
-            writer = new UdpWriter(location, parsed.hostname, Number(parsed.port));
-        } else {
-            writer = new UdpWriter(location, parsed.hostname, Number(parsed.port), logger);
-        }
+        const parsed = new URL(location);
+        return new UdpWriter(location, parsed.hostname, Number(parsed.port), log);
     } else if (location.startsWith("file://")) {
-        writer = logger == undefined ? new FileWriter(location) : new FileWriter(location, logger);
+        return new FileWriter(location, log);
     } else if (location.startsWith("udp://")) {
-        const parsed: URL = new URL(location)
+        const parsed = new URL(location);
         // convert IPv6 loop-back address from [::1] to ::1, so it works with the socket api
-        const hostname: string = parsed.hostname.replace("[::1]", "::1")
-        if (logger == undefined) {
-            writer = new UdpWriter(location, hostname, Number(parsed.port));
-        } else {
-            writer = new UdpWriter(location, hostname, Number(parsed.port), logger);
-        }
-    } else {
-        throw new Error(`unsupported Writer location: ${location}`);
+        const hostname = parsed.hostname.replace("[::1]", "::1");
+        return new UdpWriter(location, hostname, Number(parsed.port), log);
     }
 
-    return writer;
+    throw new Error(`unsupported Writer location: ${location}`);
 }

--- a/src/writer/udp_writer.ts
+++ b/src/writer/udp_writer.ts
@@ -31,6 +31,7 @@ export class UdpWriter extends Writer {
         this._flushIntervalMs = flushIntervalMs;
         this._logger.debug(`initialize UdpWriter to ${location}`);
         this._socket = createSocket(isIPv6(address) ? "udp6" : "udp4");
+        this._socket.on('error', (err) => this._logger.error(`udp socket error: ${err.message}`));
         this._lastOperation = new Promise((resolve) => {
             this._socket.connect(port, address, resolve);
         });
@@ -47,6 +48,7 @@ export class UdpWriter extends Writer {
             this.flush();
         } else if (!this._flushTimer) {
             this._flushTimer = setTimeout(() => this.flush(), this._flushIntervalMs);
+            this._flushTimer.unref();
         }
 
         return RESOLVED;
@@ -55,6 +57,7 @@ export class UdpWriter extends Writer {
     // Clears the timer synchronously (must happen before chaining, so a pending
     // timer can't schedule a flush that runs after close), then chains drainBuffer.
     close(): Promise<void> {
+        if (this._closed) return this._lastOperation;
         this._closed = true;
         if (this._flushTimer) {
             clearTimeout(this._flushTimer);

--- a/src/writer/udp_writer.ts
+++ b/src/writer/udp_writer.ts
@@ -13,18 +13,17 @@ const FLUSH_INTERVAL_MS = 15000;
  */
 export class UdpWriter extends Writer {
     private _socket: Socket;
+    private _ready: Promise<void>;
     private _buffer: string[] = [];
     private _bufferBytes = 0;
     private _flushTimer: ReturnType<typeof setTimeout> | null = null;
-    private _connected = false;
 
     constructor(location: string, address: string, port: number, logger: Logger = get_logger()) {
         super(logger);
         this._logger.debug(`initialize UdpWriter to ${location}`);
         this._socket = createSocket(isIPv6(address) ? "udp6" : "udp4");
-        this._socket.connect(port, address, () => {
-            this._connected = true;
-            this.flush();
+        this._ready = new Promise((resolve) => {
+            this._socket.connect(port, address, resolve);
         });
     }
 
@@ -42,24 +41,45 @@ export class UdpWriter extends Writer {
     }
 
     close(): Promise<void> {
-        this.flush();
-        return new Promise((resolve) => this._socket.close(resolve));
-    }
-
-    private flush(): void {
-        if (this._buffer.length === 0 || !this._connected) return;
-
         if (this._flushTimer) {
             clearTimeout(this._flushTimer);
             this._flushTimer = null;
         }
 
-        const payload = this._buffer.join("\n");
-        this._buffer = [];
-        this._bufferBytes = 0;
+        return this._ready.then(() => {
+            if (this._buffer.length === 0) {
+                return new Promise<void>((resolve) => this._socket.close(resolve));
+            }
 
-        this._socket.send(payload, (err: Error | null) => {
-            if (err) this._logger.error(`failed to send udp payload: ${err.message}`);
+            const payload = this._buffer.join("\n");
+            this._buffer = [];
+            this._bufferBytes = 0;
+
+            return new Promise<void>((resolve) => {
+                this._socket.send(payload, (err: Error | null) => {
+                    if (err) this._logger.error(`failed to send udp payload: ${err.message}`);
+                    this._socket.close(resolve);
+                });
+            });
+        });
+    }
+
+    private flush(): void {
+        this._ready.then(() => {
+            if (this._buffer.length === 0) return;
+
+            if (this._flushTimer) {
+                clearTimeout(this._flushTimer);
+                this._flushTimer = null;
+            }
+
+            const payload = this._buffer.join("\n");
+            this._buffer = [];
+            this._bufferBytes = 0;
+
+            this._socket.send(payload, (err: Error | null) => {
+                if (err) this._logger.error(`failed to send udp payload: ${err.message}`);
+            });
         });
     }
 }

--- a/src/writer/udp_writer.ts
+++ b/src/writer/udp_writer.ts
@@ -1,53 +1,65 @@
 import {Writer} from "./writer.js";
 import {get_logger, Logger} from "../logger/logger.js";
-import {createSocket, Socket, SocketType} from "node:dgram";
+import {createSocket, Socket} from "node:dgram";
 import {isIPv6} from "node:net";
 
-export class UdpWriter extends Writer {
-    /**
-     * Writer that outputs data to a UDP socket.
-     */
+const RESOLVED = Promise.resolve();
+const MAX_BUFFER_BYTES = 8192;
+const FLUSH_INTERVAL_MS = 15000;
 
-    private readonly _address: string;
-    private readonly _port: number;
-    private readonly _family: SocketType;
+/**
+ * Buffers metrics and flushes them as newline-delimited UDP packets,
+ * either when the buffer reaches MAX_BUFFER_BYTES or every FLUSH_INTERVAL_MS.
+ */
+export class UdpWriter extends Writer {
     private _socket: Socket;
+    private _buffer: string[] = [];
+    private _bufferBytes = 0;
+    private _flushTimer: ReturnType<typeof setTimeout> | null = null;
+    private _connected = false;
 
     constructor(location: string, address: string, port: number, logger: Logger = get_logger()) {
         super(logger);
         this._logger.debug(`initialize UdpWriter to ${location}`);
-        this._address = address;
-        this._port = port;
-
-        if (isIPv6(this._address)) {
-            this._family = "udp6";
-        } else {
-            // IPv4 addresses, and anything that does not appear to be an IPv4 or IPv6 address (i.e. hostnames)
-            this._family = "udp4";
-        }
-
-        this._socket = createSocket(this._family);
-    }
-
-    write(line: string): Promise<void> {
-        return new Promise((resolve: (value: void | PromiseLike<void>) => void, reject: (reason?: any) => void): void => {
-            this._logger.debug(`write line=${line}`);
-            this._socket.send(line, this._port, this._address, (err: Error | null): void => {
-                if (err) {
-                    this._logger.error(`failed to write line=${line}: ${err.message}`);
-                    reject(err);
-                } else {
-                    resolve();
-                }
-            })
+        this._socket = createSocket(isIPv6(address) ? "udp6" : "udp4");
+        this._socket.connect(port, address, () => {
+            this._connected = true;
+            this.flush();
         });
     }
 
+    write(line: string): Promise<void> {
+        this._buffer.push(line);
+        this._bufferBytes += line.length + 1;
+
+        if (this._bufferBytes >= MAX_BUFFER_BYTES) {
+            this.flush();
+        } else if (!this._flushTimer) {
+            this._flushTimer = setTimeout(() => this.flush(), FLUSH_INTERVAL_MS);
+        }
+
+        return RESOLVED;
+    }
+
     close(): Promise<void> {
-        return new Promise((resolve: (value: void | PromiseLike<void>) => void): void => {
-            this._socket.close((): void => {
-                resolve();
-            });
+        this.flush();
+        return new Promise((resolve) => this._socket.close(resolve));
+    }
+
+    private flush(): void {
+        if (this._buffer.length === 0 || !this._connected) return;
+
+        if (this._flushTimer) {
+            clearTimeout(this._flushTimer);
+            this._flushTimer = null;
+        }
+
+        const payload = this._buffer.join("\n");
+        this._buffer = [];
+        this._bufferBytes = 0;
+
+        this._socket.send(payload, (err: Error | null) => {
+            if (err) this._logger.error(`failed to send udp payload: ${err.message}`);
         });
     }
 }

--- a/src/writer/udp_writer.ts
+++ b/src/writer/udp_writer.ts
@@ -4,81 +4,97 @@ import {createSocket, Socket} from "node:dgram";
 import {isIPv6} from "node:net";
 
 const RESOLVED = Promise.resolve();
-const MAX_BUFFER_BYTES = 8192;
-const FLUSH_INTERVAL_MS = 15000;
+const DEFAULT_MAX_BUFFER_BYTES = 8192;
+const DEFAULT_FLUSH_INTERVAL_MS = 15000;
 
 /**
  * Buffers metrics and flushes them as newline-delimited UDP packets,
- * either when the buffer reaches MAX_BUFFER_BYTES or every FLUSH_INTERVAL_MS.
+ * either when the buffer reaches the configured max size or after the flush interval.
+ *
+ * All socket operations (connect, send, close) are serialized through a single
+ * Promise chain (_lastOperation) to prevent races between flush and close.
  */
 export class UdpWriter extends Writer {
     private _socket: Socket;
-    private _ready: Promise<void>;
+    private _lastOperation: Promise<void>;
     private _buffer: string[] = [];
     private _bufferBytes = 0;
     private _flushTimer: ReturnType<typeof setTimeout> | null = null;
+    private _closed = false;
+    private readonly _maxBufferBytes: number;
+    private readonly _flushIntervalMs: number;
 
-    constructor(location: string, address: string, port: number, logger: Logger = get_logger()) {
+    constructor(location: string, address: string, port: number, logger: Logger = get_logger(),
+                maxBufferBytes: number = DEFAULT_MAX_BUFFER_BYTES, flushIntervalMs: number = DEFAULT_FLUSH_INTERVAL_MS) {
         super(logger);
+        this._maxBufferBytes = maxBufferBytes;
+        this._flushIntervalMs = flushIntervalMs;
         this._logger.debug(`initialize UdpWriter to ${location}`);
         this._socket = createSocket(isIPv6(address) ? "udp6" : "udp4");
-        this._ready = new Promise((resolve) => {
+        this._lastOperation = new Promise((resolve) => {
             this._socket.connect(port, address, resolve);
         });
     }
 
+    // Appends to the buffer synchronously. Triggers a flush when the buffer
+    // exceeds the max size, or schedules one after the flush interval.
     write(line: string): Promise<void> {
+        if (this._closed) return RESOLVED;
         this._buffer.push(line);
         this._bufferBytes += line.length + 1;
 
-        if (this._bufferBytes >= MAX_BUFFER_BYTES) {
+        if (this._bufferBytes >= this._maxBufferBytes) {
             this.flush();
         } else if (!this._flushTimer) {
-            this._flushTimer = setTimeout(() => this.flush(), FLUSH_INTERVAL_MS);
+            this._flushTimer = setTimeout(() => this.flush(), this._flushIntervalMs);
         }
 
         return RESOLVED;
     }
 
+    // Clears the timer synchronously (must happen before chaining, so a pending
+    // timer can't schedule a flush that runs after close), then chains drainBuffer.
     close(): Promise<void> {
+        this._closed = true;
         if (this._flushTimer) {
             clearTimeout(this._flushTimer);
             this._flushTimer = null;
         }
 
-        return this._ready.then(() => {
-            if (this._buffer.length === 0) {
-                return new Promise<void>((resolve) => this._socket.close(resolve));
-            }
-
-            const payload = this._buffer.join("\n");
-            this._buffer = [];
-            this._bufferBytes = 0;
-
-            return new Promise<void>((resolve) => {
-                this._socket.send(payload, (err: Error | null) => {
-                    if (err) this._logger.error(`failed to send udp payload: ${err.message}`);
-                    this._socket.close(resolve);
-                });
-            });
-        });
+        this._lastOperation = this._lastOperation.then(() => this.drainBuffer(true));
+        return this._lastOperation;
     }
 
+    // Chains a drainBuffer onto _lastOperation so it waits for any in-flight send.
     private flush(): void {
-        this._ready.then(() => {
-            if (this._buffer.length === 0) return;
+        this._lastOperation = this._lastOperation.then(() => this.drainBuffer(false));
+    }
 
-            if (this._flushTimer) {
-                clearTimeout(this._flushTimer);
-                this._flushTimer = null;
-            }
+    // Sends all buffered lines as a single newline-delimited UDP packet.
+    // When andClose is true, closes the socket after the send completes.
+    private drainBuffer(andClose: boolean): Promise<void> | void {
+        if (this._flushTimer) {
+            clearTimeout(this._flushTimer);
+            this._flushTimer = null;
+        }
 
-            const payload = this._buffer.join("\n");
-            this._buffer = [];
-            this._bufferBytes = 0;
+        if (this._buffer.length === 0) {
+            if (andClose) return new Promise<void>((resolve) => this._socket.close(resolve));
+            return;
+        }
 
+        const payload = this._buffer.join("\n");
+        this._buffer = [];
+        this._bufferBytes = 0;
+
+        return new Promise<void>((resolve) => {
             this._socket.send(payload, (err: Error | null) => {
                 if (err) this._logger.error(`failed to send udp payload: ${err.message}`);
+                if (andClose) {
+                    this._socket.close(resolve);
+                } else {
+                    resolve();
+                }
             });
         });
     }

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -32,15 +32,17 @@ describe("Registry Tests", (): void => {
         assert.isTrue(writer.is_empty());
     });
 
-    it("default config", (): void => {
+    it("default config", async (): Promise<void> => {
         const r = new Registry();
         assert.isTrue(r.writer() instanceof UdpWriter);
+        await r.close();
     });
 
-    it("get config", (): void => {
+    it("get config", async (): Promise<void> => {
         const r = new Registry();
         assert.equal(r.config().location, "udp", )
         assert.deepEqual(r.config().extra_common_tags, {})
+        await r.close();
     });
 
     it("age_gauge", (): void => {

--- a/test/writer/udp_writer.test.ts
+++ b/test/writer/udp_writer.test.ts
@@ -50,9 +50,11 @@ describe("UdpWriter Tests", (): void => {
 
         await sleep(2);  // tiny pause is necessary to see data
 
-        assert.equal(messages.length, 2);
-        assert.equal(messages[0], "c:server.numRequests,id=failed:1");
-        assert.equal(messages[1], "c:server.numRequests,id=failed:2");
+        // messages are batched into newline-delimited UDP packets
+        const lines = messages.flatMap((m) => m.split("\n"));
+        assert.equal(lines.length, 2);
+        assert.equal(lines[0], "c:server.numRequests,id=failed:1");
+        assert.equal(lines[1], "c:server.numRequests,id=failed:2");
 
         messages.length = 0;  // clear server messages
     });
@@ -66,9 +68,11 @@ describe("UdpWriter Tests", (): void => {
 
         await sleep(2);  // tiny pause is necessary to see data
 
-        assert.equal(messages.length, 2);
-        assert.equal(messages[0], "c:server.numRequests,id=success:1");
-        assert.equal(messages[1], "c:server.numRequests,id=success:2");
+        // messages are batched into newline-delimited UDP packets
+        const lines = messages.flatMap((m) => m.split("\n"));
+        assert.equal(lines.length, 2);
+        assert.equal(lines[0], "c:server.numRequests,id=success:1");
+        assert.equal(lines[1], "c:server.numRequests,id=success:2");
 
         messages.length = 0;  // clear server messages
     });

--- a/test/writer/udp_writer.test.ts
+++ b/test/writer/udp_writer.test.ts
@@ -77,6 +77,120 @@ describe("UdpWriter Tests", (): void => {
         messages.length = 0;  // clear server messages
     });
 
+    it("flush on timeout", async (): Promise<void> => {
+        const address = server.address();
+        const writer = new UdpWriter(location, address.address, address.port, undefined, 8192, 50);
+
+        try {
+            await writer.write("c:server.numRequests,id=failed:1");
+            await writer.write("c:server.numRequests,id=failed:2");
+            await writer.write("c:server.numRequests,id=failed:3");
+
+            // buffer is not full, so nothing sent yet
+            assert.equal(messages.length, 0);
+
+            // wait for the 50ms flush interval to fire
+            await sleep(100);
+
+            const lines = messages.flatMap((m) => m.split("\n"));
+            assert.equal(lines.length, 3);
+            assert.equal(lines[0], "c:server.numRequests,id=failed:1");
+            assert.equal(lines[1], "c:server.numRequests,id=failed:2");
+            assert.equal(lines[2], "c:server.numRequests,id=failed:3");
+        } finally {
+            await writer.close();
+            messages.length = 0;
+        }
+    });
+
+    it("flush on buffer full", async (): Promise<void> => {
+        const address = server.address();
+        // small buffer (50 bytes), long timeout so only size triggers the flush
+        const writer = new UdpWriter(location, address.address, address.port, undefined, 50, 60000);
+
+        try {
+            await writer.write("c:server.numRequests,id=failed:1");
+            await writer.write("c:server.numRequests,id=failed:2");
+            await writer.write("c:server.numRequests,id=failed:3");
+
+            // 3 lines exceed 100 bytes, so a flush should have been triggered.
+            // wait for connect + send to complete.
+            await sleep(50);
+
+            const lines = messages.flatMap((m) => m.split("\n"));
+            assert.equal(lines.length, 3);
+        } finally {
+            await writer.close();
+            messages.length = 0;
+        }
+    });
+
+    it("flush on timeout twice", async (): Promise<void> => {
+        const address = server.address();
+        const writer = new UdpWriter(location, address.address, address.port, undefined, 8192, 50);
+
+        try {
+            // first batch
+            await writer.write("c:counter:1");
+            await writer.write("c:counter:2");
+
+            await sleep(100);
+
+            let lines = messages.flatMap((m) => m.split("\n"));
+            assert.equal(lines.length, 2);
+            assert.equal(lines[0], "c:counter:1");
+            assert.equal(lines[1], "c:counter:2");
+
+            // second batch — timer should reschedule after first flush
+            await writer.write("c:counter:3");
+            await writer.write("c:counter:4");
+
+            await sleep(100);
+
+            lines = messages.flatMap((m) => m.split("\n"));
+            assert.equal(lines.length, 4);
+            assert.equal(lines[2], "c:counter:3");
+            assert.equal(lines[3], "c:counter:4");
+        } finally {
+            await writer.close();
+            messages.length = 0;
+        }
+    });
+
+    it("buffer full resets timer", async (): Promise<void> => {
+        const address = server.address();
+        // small buffer (20 bytes), 200ms timeout
+        const writer = new UdpWriter(location, address.address, address.port, undefined, 20, 200);
+
+        try {
+            // first write (12 bytes) sets the 200ms timer
+            await writer.write("c:counter:1");
+            assert.equal(messages.length, 0);
+
+            // second write (24 bytes total) exceeds 20 bytes, triggers size-based flush
+            await writer.write("c:counter:2");
+
+            await sleep(50);
+
+            let lines = messages.flatMap((m) => m.split("\n"));
+            assert.equal(lines.length, 2);
+
+            // write again — a new timer should be set since the old one was cleared
+            await writer.write("c:counter:3");
+
+            // wait long enough for the new 200ms timer but not 400ms (which would
+            // mean the original timer was still running from the first write)
+            await sleep(300);
+
+            lines = messages.flatMap((m) => m.split("\n"));
+            assert.equal(lines.length, 3);
+            assert.equal(lines[2], "c:counter:3");
+        } finally {
+            await writer.close();
+            messages.length = 0;
+        }
+    });
+
     it("address family", (): void => {
         assert.equal(isIPv4("192.168.1.1"), true);
         assert.equal(isIPv4("2001:0db8:85a3:0000:0000:8a2e:0370:7334"), false);


### PR DESCRIPTION
## UdpWriter Performance & Codebase Simplification

### UdpWriter Performance Improvements
- **Message batching**: Metrics are buffered and sent as newline-delimited UDP packets instead of one syscall per metric, reducing overhead under load
- **Connected socket**: Socket is connected at construction time
- **Cached Promise**: `write()` returns a single pre-resolved Promise instead of allocating a new one per call
- **Configurable tuning**: Buffer size (`maxBufferBytes`, default 8192) and flush interval (`flushIntervalMs`, default 15000ms) are now constructor parameters

### UdpWriter Race Condition Fix
- All socket operations (connect, send, close) are serialized through a single Promise chain (`_lastOperation`), preventing races between timer-triggered flushes and `close()`
- `close()` clears the flush timer synchronously before chaining, so no flush can be scheduled after close
- Added `_closed` guard so `write()` is a no-op after `close()`

### Registry Simplification
- Extracted `private create<T>()` generic helper, reducing 20 duplicate meter factory methods to one-liners
- Simplified `close()` error path: `Promise.reject(error)` replaces verbose constructor

### Writer Factory Simplification (`new_writer.ts`)
- Resolved logger once at top with `logger ?? get_logger()`, eliminating 6 `logger == undefined` ternaries
- Early returns replace `else if` chains and mutable `let writer` variable
- Combined `"udp"` and `"udp://"` branches — `"udp"` rewrites the location and falls through

### Logger Simplification
- Removed dead "not implemented" stubs that were immediately overwritten by the `for` loop
- Simplified `level_filter` assignment to a `const` with ternary

### Meter Simplification
- Replaced verbose `new Promise((resolve) => { resolve() })` with `Promise.resolve()` across all meter types (counter, timer, dist_summary, percentile_timer, percentile_dist_summary)
- Removed unnecessary `else` blocks — early return handles the non-write path

### Id Simplification
- `INVALID_CHARS` regex is now `static readonly` — shared across all instances instead of recreated per `Id`
- `tags_toString` calls `Object.entries` once instead of twice
- Constructor tag initialization simplified to ternary

### Test Updates
- UDP writer tests updated to handle batched newline-delimited messages
- Registry tests close UDP writers to prevent process hangs
- Added tests: flush on timeout, flush on buffer full, flush on timeout twice, buffer full resets timer
