### PR TITLE
Bump Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator",
-  "version": "3.1.0-rc.1",
+  "version": "3.1.0-rc.2",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Netflix/spectator-js",
   "author": "Netflix Telemetry Engineering <netflix-atlas@googlegroups.com>",


### PR DESCRIPTION
I forgot to bump the version in pr#113 pushed a follow-up commit moving package.json from 3.1.0-rc.1 to 3.1.0-rc.2.