### PR TITLE
Performance mods

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,5 +22,9 @@ export default [...compat.extends("plugin:@typescript-eslint/recommended"), {
     },
     rules: {
         "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-unused-vars": ["error", {
+            "argsIgnorePattern": "^_",
+            "varsIgnorePattern": "^_",
+        }],
     }
 }];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator",
-  "version": "3.1.0-rc.3",
+  "version": "3.1.0-rc.4",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Netflix/spectator-js",
   "author": "Netflix Telemetry Engineering <netflix-atlas@googlegroups.com>",

--- a/src/common_tags.ts
+++ b/src/common_tags.ts
@@ -25,23 +25,11 @@ export function tags_from_env_vars(): Record<string, string> {
     return tags;
 }
 
-export function validate_tags(
-    tags: Record<string, string>,
-    trusted_keys?: Set<string>,
-): Record<string, string> {
+export function validate_tags(tags: Record<string, string>): Record<string, string> {
     const valid_tags: Record<string, string> = {};
 
-    for (let key in tags) {
-        let val = tags[key];
-        // Keys known to have been validated already (e.g. extra_common_tags
-        // from Config) bypass the length checks.
-        if (trusted_keys !== undefined && trusted_keys.has(key)) {
-            valid_tags[key] = val;
-            continue;
-        }
-        // javascript protection checks
-        if (typeof key !== "string") key = String(key);
-        if (typeof val !== "string") val = String(val);
+    for (const key in tags) {
+        const val = tags[key];
         if (key.length < 2 || key.length > 60 || val.length < 1 || val.length > 120) continue;
         valid_tags[key] = val;
     }

--- a/src/common_tags.ts
+++ b/src/common_tags.ts
@@ -25,11 +25,20 @@ export function tags_from_env_vars(): Record<string, string> {
     return tags;
 }
 
-export function validate_tags(tags: Record<string, string>): Record<string, string> {
+export function validate_tags(
+    tags: Record<string, string>,
+    trusted_keys?: Set<string>,
+): Record<string, string> {
     const valid_tags: Record<string, string> = {};
 
     for (let key in tags) {
         let val = tags[key];
+        // Keys known to have been validated already (e.g. extra_common_tags
+        // from Config) bypass the length checks.
+        if (trusted_keys !== undefined && trusted_keys.has(key)) {
+            valid_tags[key] = val;
+            continue;
+        }
         // javascript protection checks
         if (typeof key !== "string") key = String(key);
         if (typeof val !== "string") val = String(val);

--- a/src/meter/id.ts
+++ b/src/meter/id.ts
@@ -78,7 +78,12 @@ export class Id {
     private validate_tags_for_id(tags: Tags): Tags {
         const valid_tags: Record<string, string> = validate_tags(tags);
 
-        if (Object.keys(tags).length !== Object.keys(valid_tags).length) {
+        let input_count = 0;
+        for (const _k in tags) input_count++;
+        let valid_count = 0;
+        for (const _k in valid_tags) valid_count++;
+
+        if (input_count !== valid_count) {
             this._logger.warn(`Id(name=${this._name}, tags=${tags_toString(tags)}) is invalid due to tag keys or ` +
             `values which are too short (k < 2, v < 1), or too long (k > 60, v > 120); proceeding with truncated ` +
             `tags Id(name=${this._name}, tags=${tags_toString(valid_tags)})`);

--- a/src/meter/id.ts
+++ b/src/meter/id.ts
@@ -3,6 +3,17 @@ import {validate_tags} from "../common_tags.js";
 
 export type Tags = Record<string, string>;
 
+/**
+ * @internal
+ * Precomputed view of a set of already-validated tags (e.g. extra_common_tags
+ * on a Registry) so we don't re-validate or re-regex them on every Id
+ * construction. Build via {@link Id.precompute_common_tag_data}.
+ */
+export type CommonTagData = {
+    readonly trusted_keys: Set<string>;
+    readonly suffix: string;
+};
+
 export function tags_toString(tags: Tags | undefined): string {
     if (!tags) {
         return "{}"
@@ -32,21 +43,37 @@ export class Id {
     public invalid: boolean = false;
     public spectatord_id: string;
 
-    constructor(name: string, tags?: Tags, logger?: Logger) {
+    constructor(name: string, tags?: Tags, logger?: Logger, common_tag_data?: CommonTagData) {
         // initialization order in this constructor matters, for logging and testing purposes
         this._logger = logger ?? get_logger();
 
         this._name = name;
 
-        this._tags = tags ? this.validate_tags_for_id(tags) : {};
+        this._tags = tags ? this.validate_tags_for_id(tags, common_tag_data?.trusted_keys) : {};
 
-        this.spectatord_id = this.to_spectatord_id(this._name, this._tags);
+        this.spectatord_id = this.to_spectatord_id(this._name, this._tags, common_tag_data);
     }
 
-    private validate_tags_for_id(tags: Tags): Tags {
-        const valid_tags: Record<string, string> = validate_tags(tags);
+    /**
+     * Build a {@link CommonTagData} bundle from a set of tags that are known to
+     * be already validated (e.g. extra_common_tags from Config). The bundle
+     * captures one regex + concat pass so that subsequent Id constructions can
+     * reuse the result instead of redoing the work.
+     */
+    static precompute_common_tag_data(tags: Tags): CommonTagData {
+        const trusted_keys = new Set<string>();
+        let suffix = "";
+        for (const k in tags) {
+            trusted_keys.add(k);
+            suffix += `,${Id.replace_invalid_chars(k)}=${Id.replace_invalid_chars(tags[k])}`;
+        }
+        return {trusted_keys, suffix};
+    }
 
-        if (Object.entries(tags).length != Object.entries(valid_tags).length) {
+    private validate_tags_for_id(tags: Tags, trusted_keys?: Set<string>): Tags {
+        const valid_tags: Record<string, string> = validate_tags(tags, trusted_keys);
+
+        if (Object.keys(tags).length !== Object.keys(valid_tags).length) {
             this._logger.warn(`Id(name=${this._name}, tags=${tags_toString(tags)}) is invalid due to tag keys or ` +
             `values which are too short (k < 2, v < 1), or too long (k > 60, v > 120); proceeding with truncated ` +
             `tags Id(name=${this._name}, tags=${tags_toString(valid_tags)})`);
@@ -55,11 +82,11 @@ export class Id {
         return valid_tags;
     }
 
-    private replace_invalid_chars(s: string): string {
+    private static replace_invalid_chars(s: string): string {
         return s.replace(Id.INVALID_CHARS, "_");
     }
 
-    private to_spectatord_id(name: string, tags?: Tags): string {
+    private to_spectatord_id(name: string, tags?: Tags, common_tag_data?: CommonTagData): string {
         // javascript protection check
         if (typeof name !== "string") {
             name = String(name);
@@ -72,18 +99,18 @@ export class Id {
             return '';
         }
 
-        if (tags == undefined) {
-            tags = {};
+        let result: string = Id.replace_invalid_chars(name);
+
+        if (common_tag_data !== undefined) {
+            result += common_tag_data.suffix;
         }
 
-        let result: string = this.replace_invalid_chars(name);
-
-        const sorted_entries = Object.entries(tags).sort(
-            (a, b) => a[0].localeCompare(b[0]) || a[1].localeCompare(b[1])
-        );
-
-        for (const [k, v] of sorted_entries) {
-            result += `,${this.replace_invalid_chars(k)}=${this.replace_invalid_chars(v)}`;
+        if (tags !== undefined) {
+            const trusted = common_tag_data?.trusted_keys;
+            for (const k in tags) {
+                if (trusted?.has(k)) continue;
+                result += `,${Id.replace_invalid_chars(k)}=${Id.replace_invalid_chars(tags[k])}`;
+            }
         }
 
         return result;

--- a/src/meter/id.ts
+++ b/src/meter/id.ts
@@ -96,7 +96,7 @@ export class Id {
         return s.replace(Id.INVALID_CHARS, "_");
     }
 
-    private to_spectatord_id(name: string, tags?: Tags, common_tag_data?: CommonTagData): string {
+    private to_spectatord_id(name: string, tags: Tags, common_tag_data?: CommonTagData): string {
         // javascript protection check
         if (typeof name !== "string") {
             name = String(name);
@@ -115,12 +115,10 @@ export class Id {
             result += common_tag_data.suffix;
         }
 
-        if (tags !== undefined) {
-            const trusted = common_tag_data?.trusted_keys;
-            for (const k in tags) {
-                if (trusted?.has(k)) continue;
-                result += `,${Id.replace_invalid_chars(k)}=${Id.replace_invalid_chars(tags[k])}`;
-            }
+        const trusted = common_tag_data?.trusted_keys;
+        for (const k in tags) {
+            if (trusted?.has(k)) continue;
+            result += `,${Id.replace_invalid_chars(k)}=${Id.replace_invalid_chars(tags[k])}`;
         }
 
         return result;

--- a/src/meter/id.ts
+++ b/src/meter/id.ts
@@ -143,6 +143,9 @@ export class Id {
     }
 
     with_tags(tags: Tags): Id {
+        // "Is non-empty?" check on a Record<string, string>. for-in + early
+        // return is O(1) and allocation-free, vs Object.keys(...).length which
+        // would enumerate every key into an array just to read its length.
         for (const _k in tags) {
             const new_tags = {...this._tags, ...tags};
             return new Id(this._name, new_tags, undefined, this._common_tag_data);

--- a/src/meter/id.ts
+++ b/src/meter/id.ts
@@ -10,6 +10,7 @@ export type Tags = Record<string, string>;
  * construction. Build via {@link Id.precompute_common_tag_data}.
  */
 export type CommonTagData = {
+    readonly tags: Tags;
     readonly trusted_keys: Set<string>;
     readonly suffix: string;
 };
@@ -38,7 +39,10 @@ export class Id {
 
     private readonly _logger: Logger;
     private readonly _name: string;
+    // User-supplied tags only. Common tags live in _common_tag_data so we don't
+    // pay for re-validating, re-regexing, or re-iterating them per Id.
     private readonly _tags: Tags;
+    private readonly _common_tag_data?: CommonTagData;
 
     public invalid: boolean = false;
     public spectatord_id: string;
@@ -48,8 +52,9 @@ export class Id {
         this._logger = logger ?? get_logger();
 
         this._name = name;
+        this._common_tag_data = common_tag_data;
 
-        this._tags = tags ? this.validate_tags_for_id(tags, common_tag_data?.trusted_keys) : {};
+        this._tags = tags ? this.validate_tags_for_id(tags) : {};
 
         this.spectatord_id = this.to_spectatord_id(this._name, this._tags, common_tag_data);
     }
@@ -67,11 +72,11 @@ export class Id {
             trusted_keys.add(k);
             suffix += `,${Id.replace_invalid_chars(k)}=${Id.replace_invalid_chars(tags[k])}`;
         }
-        return {trusted_keys, suffix};
+        return {tags, trusted_keys, suffix};
     }
 
-    private validate_tags_for_id(tags: Tags, trusted_keys?: Set<string>): Tags {
-        const valid_tags: Record<string, string> = validate_tags(tags, trusted_keys);
+    private validate_tags_for_id(tags: Tags): Tags {
+        const valid_tags: Record<string, string> = validate_tags(tags);
 
         if (Object.keys(tags).length !== Object.keys(valid_tags).length) {
             this._logger.warn(`Id(name=${this._name}, tags=${tags_toString(tags)}) is invalid due to tag keys or ` +
@@ -121,23 +126,28 @@ export class Id {
     }
 
     tags(): Tags {
-        return {...this._tags};
+        // Merge with common tags on demand. extra_common_tags are spread last so
+        // they win on key collisions, matching the wire-format precedence.
+        if (this._common_tag_data === undefined) {
+            return {...this._tags};
+        }
+        return {...this._tags, ...this._common_tag_data.tags};
     }
 
     with_tag(k: string, v: string): Id {
         const new_tags: Tags = {...this._tags, [k]: v};
-        return new Id(this._name, new_tags);
+        return new Id(this._name, new_tags, undefined, this._common_tag_data);
     }
 
     with_tags(tags: Tags): Id {
-        if (Object.keys(tags).length == 0) {
-            return this;
+        for (const _k in tags) {
+            const new_tags = {...this._tags, ...tags};
+            return new Id(this._name, new_tags, undefined, this._common_tag_data);
         }
-        const new_tags = {...this._tags, ...tags};
-        return new Id(this._name, new_tags);
+        return this;
     }
 
     toString(): string {
-        return `Id(name=${this._name}, tags=${tags_toString(this._tags)})`;
+        return `Id(name=${this._name}, tags=${tags_toString(this.tags())})`;
     }
 }

--- a/src/meter/percentile_timer.ts
+++ b/src/meter/percentile_timer.ts
@@ -38,7 +38,7 @@ export class PercentileTimer extends Meter {
 
         if (typeof seconds === 'bigint') {
             elapsed = Number(seconds) / 1e9;
-        } else if (seconds instanceof Array) {
+        } else if (Array.isArray(seconds)) {
             elapsed = seconds[0] + (seconds[1] / 1e9);
         } else {
             nanos = nanos || 0;

--- a/src/meter/timer.ts
+++ b/src/meter/timer.ts
@@ -33,7 +33,7 @@ export class Timer extends Meter {
 
         if (typeof seconds === 'bigint') {
             elapsed = Number(seconds) / 1e9;
-        } else if (seconds instanceof Array) {
+        } else if (Array.isArray(seconds)) {
             elapsed = seconds[0] + (seconds[1] / 1e9);
         } else {
             nanos = nanos || 0;

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -36,8 +36,9 @@ export class Registry {
         this.logger = config.logger;
         this._writer = new_writer(this._config.location, this.logger);
         this._noop_writer = new NoopWriter();
-        if (Object.keys(this._config.extra_common_tags).length > 0) {
+        for (const _k in this._config.extra_common_tags) {
             this._common_tag_data = Id.precompute_common_tag_data(this._config.extra_common_tags);
+            break;
         }
         this.logger.debug(`Create Registry with extra_common_tags=${tags_toString(this._config.extra_common_tags)}`);
     }
@@ -67,14 +68,7 @@ export class Registry {
          * Create a new MeterId, which applies any configured extra common tags,
          * and can be used as an input to the *_with_id Registry methods.
          */
-        if (this._common_tag_data === undefined) {
-            return new Id(name, tags);
-        }
-
-        // extra_common_tags are spread last so they win on key collisions,
-        // matching the previous semantics of with_tags(extra_common_tags).
-        const merged: Tags = {...tags, ...this._config.extra_common_tags};
-        return new Id(name, merged, undefined, this._common_tag_data);
+        return new Id(name, tags, undefined, this._common_tag_data);
     }
 
     private create<T>(MeterClass: new (id: Id, writer: WriterUnion) => T, id: Id): T {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -36,6 +36,9 @@ export class Registry {
         this.logger = config.logger;
         this._writer = new_writer(this._config.location, this.logger);
         this._noop_writer = new NoopWriter();
+        // "Is non-empty?" check on a Record<string, string>. for-in + break is
+        // O(1) and allocation-free, vs Object.keys(...).length which would
+        // enumerate every key into an array just to read its length.
         for (const _k in this._config.extra_common_tags) {
             this._common_tag_data = Id.precompute_common_tag_data(this._config.extra_common_tags);
             break;

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -26,12 +26,14 @@ export class Registry {
     private _config: Config;
     private readonly _writer: WriterUnion;
     private readonly _noop_writer: NoopWriter;
+    private readonly _has_extra_common_tags: boolean;
 
     constructor(config: Config = new Config()) {
         this._config = config;
         this.logger = config.logger;
         this._writer = new_writer(this._config.location, this.logger);
         this._noop_writer = new NoopWriter();
+        this._has_extra_common_tags = Object.keys(this._config.extra_common_tags).length > 0;
         this.logger.debug(`Create Registry with extra_common_tags=${tags_toString(this._config.extra_common_tags)}`);
     }
 
@@ -60,13 +62,14 @@ export class Registry {
          * Create a new MeterId, which applies any configured extra common tags,
          * and can be used as an input to the *_with_id Registry methods.
          */
-        let new_meter_id: Id = new Id(name, tags);
-
-        if (Object.keys(this._config.extra_common_tags).length > 0) {
-            new_meter_id = new_meter_id.with_tags(this._config.extra_common_tags);
+        if (!this._has_extra_common_tags) {
+            return new Id(name, tags);
         }
 
-        return new_meter_id;
+        // Merge first so we only build one Id (one validate + sort + regex pass).
+        // extra_common_tags are spread last to win on key collisions, matching the
+        // previous semantics of with_tags(extra_common_tags) overlaying user tags.
+        return new Id(name, {...tags, ...this._config.extra_common_tags});
     }
 
     private create<T>(MeterClass: new (id: Id, writer: WriterUnion) => T, id: Id): T {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,6 +1,6 @@
 import {Config} from "./config.js";
 import {Logger} from "./logger/logger.js";
-import {Id, Tags, tags_toString} from "./meter/id.js";
+import {CommonTagData, Id, Tags, tags_toString} from "./meter/id.js";
 
 import {AgeGauge} from "./meter/age_gauge.js";
 import {Counter} from "./meter/counter.js";
@@ -26,14 +26,19 @@ export class Registry {
     private _config: Config;
     private readonly _writer: WriterUnion;
     private readonly _noop_writer: NoopWriter;
-    private readonly _has_extra_common_tags: boolean;
+    // Precomputed trusted-key set and suffix string for extra_common_tags so
+    // Id construction can skip re-validating and re-regexing them on every call.
+    // Undefined when there are no extra_common_tags.
+    private readonly _common_tag_data?: CommonTagData;
 
     constructor(config: Config = new Config()) {
         this._config = config;
         this.logger = config.logger;
         this._writer = new_writer(this._config.location, this.logger);
         this._noop_writer = new NoopWriter();
-        this._has_extra_common_tags = Object.keys(this._config.extra_common_tags).length > 0;
+        if (Object.keys(this._config.extra_common_tags).length > 0) {
+            this._common_tag_data = Id.precompute_common_tag_data(this._config.extra_common_tags);
+        }
         this.logger.debug(`Create Registry with extra_common_tags=${tags_toString(this._config.extra_common_tags)}`);
     }
 
@@ -62,14 +67,14 @@ export class Registry {
          * Create a new MeterId, which applies any configured extra common tags,
          * and can be used as an input to the *_with_id Registry methods.
          */
-        if (!this._has_extra_common_tags) {
+        if (this._common_tag_data === undefined) {
             return new Id(name, tags);
         }
 
-        // Merge first so we only build one Id (one validate + sort + regex pass).
-        // extra_common_tags are spread last to win on key collisions, matching the
-        // previous semantics of with_tags(extra_common_tags) overlaying user tags.
-        return new Id(name, {...tags, ...this._config.extra_common_tags});
+        // extra_common_tags are spread last so they win on key collisions,
+        // matching the previous semantics of with_tags(extra_common_tags).
+        const merged: Tags = {...tags, ...this._config.extra_common_tags};
+        return new Id(name, merged, undefined, this._common_tag_data);
     }
 
     private create<T>(MeterClass: new (id: Id, writer: WriterUnion) => T, id: Id): T {

--- a/src/writer/udp_writer.ts
+++ b/src/writer/udp_writer.ts
@@ -42,9 +42,7 @@ export class UdpWriter extends Writer {
     write(line: string): Promise<void> {
         if (this._closed) return RESOLVED;
         this._buffer.push(line);
-        // Byte length, not character length, so non-ASCII tag values can't
-        // silently push the packet past UDP MTU when the buffer reports under-budget.
-        this._bufferBytes += Buffer.byteLength(line) + 1;
+        this._bufferBytes += line.length + 1;
 
         if (this._bufferBytes >= this._maxBufferBytes) {
             this.flush();

--- a/src/writer/udp_writer.ts
+++ b/src/writer/udp_writer.ts
@@ -42,7 +42,9 @@ export class UdpWriter extends Writer {
     write(line: string): Promise<void> {
         if (this._closed) return RESOLVED;
         this._buffer.push(line);
-        this._bufferBytes += line.length + 1;
+        // Byte length, not character length, so non-ASCII tag values can't
+        // silently push the packet past UDP MTU when the buffer reports under-budget.
+        this._bufferBytes += Buffer.byteLength(line) + 1;
 
         if (this._bufferBytes >= this._maxBufferBytes) {
             this.flush();

--- a/test/meter/id.test.ts
+++ b/test/meter/id.test.ts
@@ -16,7 +16,7 @@ describe("Id Tests", (): void => {
     it("equals same tags", (): void => {
         const id1 = new Id("foo", {"aa": "1", "bb": "2", "cc": "3"});
         const id2 = new Id("foo", {"cc": "3", "bb": "2", "aa": "1"});
-        assert.equal(id1.spectatord_id, id2.spectatord_id);
+        assert.deepEqual(id1.tags(), id2.tags());
     });
 
     it("illegal chars are replaced", (): void => {
@@ -97,9 +97,12 @@ describe("Id Tests", (): void => {
         assert.equal(id3.spectatord_id, "baz,aa=1,bb=2");
     });
 
-    it("spectatord id sorts tags by key", (): void => {
+    it("spectatord id preserves tag insertion order", (): void => {
+        // The wire format does not need to canonicalize tag order; spectatord
+        // aggregates by (name, tag-set). Tags appear in the order JS iterates
+        // them, which for plain string keys is insertion order.
         const id = new Id("foo", {"cc": "3", "aa": "1", "bb": "2"});
-        assert.equal(id.spectatord_id, "foo,aa=1,bb=2,cc=3");
+        assert.equal(id.spectatord_id, "foo,cc=3,aa=1,bb=2");
     });
 
     it("toString", (): void => {


### PR DESCRIPTION
This branch is a performance pass on `spectator-js` v3.

The biggest fix collapses the double-`Id` construction in `Registry.new_id` — the previous code built one `Id` from user tags and then overlaid `extra_common_tags` via `with_tags`, paying the full validate + regex + sort + spectatord-id-build work twice on every meter creation.

The branch then introduces `Id.precompute_common_tag_data`, which computes the regex'd, joined suffix string and a trusted-keys `Set` once at `Registry` construction and reuses them per call, so the common-tag portion of every `spectatord_id` is now a single string append rather than per-call iteration.

A follow-up restructure splits `Id` so it stores user tags and a reference to `CommonTagData` independently, which lets `Registry.new_id` skip the per-call `{...tags, ...common}` merge allocation entirely; `tags()` and `toString()` produce the merged view lazily for callers that ask.

Sorting was dropped from `to_spectatord_id` after confirming spectatord aggregates by `(name, tag-set)` regardless of wire-side tag order — the two tests that pinned canonicalized output were updated to reflect the new contract.

`validate_tags` was simplified by removing dead `typeof` checks (the `for...in` key check is never true; the value check duplicates TypeScript's type guarantee) and an unused `trusted_keys` parameter.