### PR TITLE
Fix uds error

### DIFF
--- a/src/writer/uds_writer.ts
+++ b/src/writer/uds_writer.ts
@@ -2,6 +2,8 @@ import {Writer} from "./writer.js";
 import {get_logger, Logger} from "../logger/logger.js";
 import {DgramSocket} from "node-unix-socket";
 import {statSync, unlinkSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
 
 const RESOLVED = Promise.resolve();
 const DEFAULT_MAX_BUFFER_BYTES = 32768;
@@ -56,10 +58,12 @@ export class UdsWriter extends Writer {
         }
 
         // SOCK_DGRAM unix sockets need a return-address bind on the client
-        // side. Use pid + a short random suffix so multiple Registries in
-        // the same process don't collide.
+        // side. Bind in tmpdir rather than next to destPath — spectatord's
+        // socket directory (e.g. /run/spectatord) is typically not writable
+        // by the client process. Pid + random suffix prevents collisions
+        // between multiple Registries in the same process.
         const suffix = Math.random().toString(36).slice(2, 8);
-        this._clientPath = `${destPath}.${process.pid}.${suffix}`;
+        this._clientPath = join(tmpdir(), `spectator-js.${process.pid}.${suffix}.unix`);
         this._logger.debug(`initialize UdsWriter to ${location}`);
 
         this._socket = new DgramSocket();

--- a/test/sampe.test.ts
+++ b/test/sampe.test.ts
@@ -1,0 +1,8 @@
+import {Config, Registry} from "../src/index.js";
+
+const registry = new Registry(new Config("unix"));
+const counter = registry.counter("sample.counter");
+
+setInterval(() => {
+    void counter.increment();
+}, 10_000);


### PR DESCRIPTION
The client-side return-address socket was being bound next to the destination socket (e.g. /run/spectatord/spectatord.unix.<pid>.<rand>). Non-root clients typically lack write access to spectatord's socket directory, causing bind() to fail with EACCES.

Bind in os.tmpdir() instead — the path is purely a return address for SOCK_DGRAM and doesn't need to live next to the destination.