### PR TITLE
Improve UDS Writer

### DIFF
--- a/src/writer/new_writer.ts
+++ b/src/writer/new_writer.ts
@@ -54,7 +54,21 @@ export function new_writer(location: string, logger?: Logger): WriterUnion {
     if (location.startsWith("unix://")) {
         // unix:///abs/path/socket — strip the scheme to get the filesystem path.
         const path = location.slice("unix://".length);
-        return new UdsWriter(location, path, log);
+        try {
+            return new UdsWriter(location, path, log);
+        } catch (err) {
+            // UDS init only really fails when the spectatord socket is missing
+            // or the client bind path isn't writable — both signal "this host
+            // has no spectatord." Fall back to UDP so tests and dev
+            // environments behave like the historical UDP default (silent
+            // drop) instead of crashing at Registry construction. The
+            // underlying errno isn't reliably preserved across the
+            // statSync/node-unix-socket boundary (node-unix-socket surfaces
+            // bind errors with code='Unknown'), so we can't narrow by code —
+            // catching all errors here is intentional.
+            log.warn(`UDS unavailable (${(err as Error).message}); falling back to udp://127.0.0.1:1234`);
+            return new UdpWriter("udp://127.0.0.1:1234", "127.0.0.1", 1234, log);
+        }
     }
 
     throw new Error(`unsupported Writer location: ${location}`);

--- a/src/writer/uds_writer.ts
+++ b/src/writer/uds_writer.ts
@@ -49,7 +49,9 @@ export class UdsWriter extends Writer {
         } catch (err) {
             const code = (err as NodeJS.ErrnoException).code;
             if (code === "ENOENT") {
-                throw new Error(`UDS destination does not exist: ${destPath}`);
+                const wrapped = new Error(`UDS destination does not exist: ${destPath}`) as NodeJS.ErrnoException;
+                wrapped.code = "ENOENT";
+                throw wrapped;
             }
             throw err;
         }


### PR DESCRIPTION
## Fall back to UDP when UDS is unavailable

`UdsWriter` validates the spectatord socket at construction and throws when it's missing — which is the right behavior in production but crashes every downstream test suite (atlas-adapter, NodeQuark, etc.) on machines without a running spectatord. As `unix` becomes the new default, this asymmetry with `UdpWriter` (which silently drops packets to a missing destination) bites every consumer.

### Change

`new_writer` now wraps the `UdsWriter` constructor: if it throws, log a warning and return a `UdpWriter` pointed at `udp://127.0.0.1:1234`.

### Net behavior

| Environment | Before | After |
| --- | --- | --- |
| Prod with spectatord running | UDS | UDS (unchanged) |
| Tests / dev without spectatord | crash | UDP, silently drops (matches historical UDP-default behavior) |

No consumer test changes needed.

### Notes

- Also tightened `UdsWriter` to preserve `code: "ENOENT"` on its wrapped stat error so callers (including the fallback) can introspect it if they ever want to.
- The fallback itself catches **all** errors intentionally — `node-unix-socket` surfaces `bind()` failures with `code: "Unknown"`, so narrowing by errno isn't reliable here.
