### PR TITLE
Config buffer size

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,11 @@ export class Config {
      * The output location can be overridden by configuring an environment variable SPECTATOR_OUTPUT_LOCATION
      * with one of the values listed above. Overriding the output location may be useful for integration testing.
      *
+     * The optional `buffer_size_bytes` controls how many bytes the UDP and UDS writers accumulate before
+     * flushing a batched datagram; it is ignored by the non-buffering writers (memory, file, etc.). When
+     * omitted, the writer default (32768) is used. Lower values flush sooner (smaller datagrams, more
+     * syscalls); higher values batch more aggressively. Must be a positive integer if provided.
+     *
      * UDS support is provided by the `node-unix-socket` package (napi-rs based, ships prebuilt binaries
      * for common Linux/macOS targets — no node-gyp / build toolchain required at install time). spectatord's
      * UDS endpoint accepts SOCK_DGRAM datagrams and supports higher throughput than the UDP listener
@@ -36,11 +41,24 @@ export class Config {
     location: string;
     extra_common_tags: Tags;
     logger: Logger;
+    buffer_size_bytes?: number;
 
-    constructor(location: string = "unix", extra_common_tags: Tags = {}, logger: Logger = get_logger()) {
+    constructor(location: string = "unix", extra_common_tags: Tags = {}, logger: Logger = get_logger(),
+                buffer_size_bytes?: number) {
         this.location = this.calculate_location(location);
         this.extra_common_tags = this.calculate_extra_common_tags(extra_common_tags);
         this.logger = logger;
+        this.buffer_size_bytes = this.validate_buffer_size(buffer_size_bytes);
+    }
+
+    validate_buffer_size(buffer_size_bytes?: number): number | undefined {
+        if (buffer_size_bytes === undefined) {
+            return undefined;
+        }
+        if (!Number.isInteger(buffer_size_bytes) || buffer_size_bytes <= 0) {
+            throw new Error(`buffer_size_bytes must be a positive integer: ${buffer_size_bytes}`);
+        }
+        return buffer_size_bytes;
     }
 
     calculate_extra_common_tags(common_tags: Tags): Tags {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -34,7 +34,7 @@ export class Registry {
     constructor(config: Config = new Config()) {
         this._config = config;
         this.logger = config.logger;
-        this._writer = new_writer(this._config.location, this.logger);
+        this._writer = new_writer(this._config.location, this.logger, this._config.buffer_size_bytes);
         this._noop_writer = new NoopWriter();
         // "Is non-empty?" check on a Record<string, string>. for-in + break is
         // O(1) and allocation-free, vs Object.keys(...).length which would

--- a/src/writer/new_writer.ts
+++ b/src/writer/new_writer.ts
@@ -17,9 +17,11 @@ export function is_valid_output_location(location: string): boolean {
         location.startsWith("unix://");
 }
 
-export function new_writer(location: string, logger?: Logger): WriterUnion {
+export function new_writer(location: string, logger?: Logger, buffer_size_bytes?: number): WriterUnion {
     /**
-     * Create a new Writer based on an output location.
+     * Create a new Writer based on an output location. The optional
+     * buffer_size_bytes is forwarded to the buffering writers (UDP and UDS) as
+     * their max buffer size; it is ignored by the non-buffering writers.
      */
 
     const log = logger ?? get_logger();
@@ -49,13 +51,13 @@ export function new_writer(location: string, logger?: Logger): WriterUnion {
         const parsed = new URL(location);
         // convert IPv6 bracket notation [::1] to ::1 for the socket api
         const hostname = parsed.hostname.replace("[::1]", "::1");
-        return new UdpWriter(location, hostname, Number(parsed.port), log);
+        return new UdpWriter(location, hostname, Number(parsed.port), log, buffer_size_bytes);
     }
     if (location.startsWith("unix://")) {
         // unix:///abs/path/socket — strip the scheme to get the filesystem path.
         const path = location.slice("unix://".length);
         try {
-            return new UdsWriter(location, path, log);
+            return new UdsWriter(location, path, log, buffer_size_bytes);
         } catch (err) {
             // UDS init only really fails when the spectatord socket is missing
             // or the client bind path isn't writable — both signal "this host
@@ -67,7 +69,7 @@ export function new_writer(location: string, logger?: Logger): WriterUnion {
             // bind errors with code='Unknown'), so we can't narrow by code —
             // catching all errors here is intentional.
             log.warn(`UDS unavailable (${(err as Error).message}); falling back to udp://127.0.0.1:1234`);
-            return new UdpWriter("udp://127.0.0.1:1234", "127.0.0.1", 1234, log);
+            return new UdpWriter("udp://127.0.0.1:1234", "127.0.0.1", 1234, log, buffer_size_bytes);
         }
     }
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -70,4 +70,20 @@ describe("Config Tests", (): void => {
     it("invalid output location throws", (): void => {
         assert.throws((): string => get_location("foo"));
     });
+
+    it("buffer size defaults to undefined", (): void => {
+        const config = new Config("udp");
+        assert.equal(config.buffer_size_bytes, undefined);
+    });
+
+    it("buffer size is stored", (): void => {
+        const config = new Config("udp", undefined, undefined, 8192);
+        assert.equal(config.buffer_size_bytes, 8192);
+    });
+
+    it("invalid buffer size throws", (): void => {
+        assert.throws((): Config => new Config("udp", undefined, undefined, 0));
+        assert.throws((): Config => new Config("udp", undefined, undefined, -1));
+        assert.throws((): Config => new Config("udp", undefined, undefined, 1.5));
+    });
 });

--- a/test/sample.ts
+++ b/test/sample.ts
@@ -1,8 +1,31 @@
 import {Config, Registry} from "../src/index.js";
+import process from "node:process";
+
+const MAX_DURATION_SECS = 2 * 60;
 
 const registry = new Registry(new Config("unix"));
 const counter = registry.counter("sample.counter");
 
-setInterval(() => {
+// Node is single-threaded, so there is only ever one worker driving the loop.
+const numThreads = 1;
+
+let iterations = 0;
+const start = process.hrtime.bigint();
+const deadline = start + BigInt(MAX_DURATION_SECS) * 1_000_000_000n;
+
+while (process.hrtime.bigint() < deadline) {
     void counter.increment();
-}, 10_000);
+    iterations++;
+}
+
+const elapsed = Number(process.hrtime.bigint() - start) / 1e9;
+const rate = iterations / elapsed;
+
+console.log("\nPerformance Test Summary:");
+console.log(`Threads used: ${numThreads}`);
+console.log(`Iterations completed: ${iterations}`);
+console.log(`Total elapsed time: ${elapsed.toFixed(2)} seconds`);
+console.log(`Rate: ${rate.toFixed(2)} iterations/second`);
+console.log(`Rate per thread: ${(rate / numThreads).toFixed(2)} iterations/second/thread`);
+
+await registry.close();

--- a/test/sample.ts
+++ b/test/sample.ts
@@ -5,12 +5,13 @@ import {setImmediate} from "node:timers";
 const MAX_DURATION_SECS = 2 * 60;
 
 function printUsage(): void {
-    console.error("Usage: sample [writer_type]");
+    console.error("Usage: sample [writer_type] [buffer_size_bytes]");
     console.error("  writer_type: udp or unix (default is unix)");
+    console.error("  buffer_size_bytes: positive integer (default is the writer default, 32768)");
 }
 
 const args = process.argv.slice(2);
-if (args.length > 1) {
+if (args.length > 2) {
     printUsage();
     process.exit(1);
 }
@@ -22,13 +23,24 @@ if (writerType !== "udp" && writerType !== "unix") {
     process.exit(1);
 }
 
-const registry = new Registry(new Config(writerType));
+let bufferSize: number | undefined;
+if (args[1] !== undefined) {
+    bufferSize = Number(args[1]);
+    if (!Number.isInteger(bufferSize) || bufferSize <= 0) {
+        console.error(`Invalid buffer size: ${args[1]}`);
+        printUsage();
+        process.exit(1);
+    }
+}
+
+const registry = new Registry(new Config(writerType, undefined, undefined, bufferSize));
 const tags = {
     location: writerType,
     version: "correct-horse-battery-staple",
 };
 
 console.log(`Writer Type: ${writerType}`);
+console.log(`Buffer Size: ${bufferSize ?? "default (32768)"}`);
 
 // Node is single-threaded, so there is only ever one worker driving the loop.
 const numThreads = 1;
@@ -37,10 +49,11 @@ const numThreads = 1;
 // loop runs, flushing the *entire* accumulated buffer as one datagram. A
 // synchronous loop never yields, so the buffer balloons and the first drain
 // tries to send an oversized datagram -> EMSGSIZE ("Message too long"). Yield
-// once we've buffered ~16KB so each datagram stays well under the OS limit.
-// This must be bound by bytes, not wall-clock time: at high throughput even a
-// sub-second interval buffers megabytes, far past the datagram size limit.
-const YIELD_BYTES = 16 * 1024;
+// once we've buffered roughly one buffer's worth so the writer's size-triggered
+// flush runs and each datagram is ~buffer_size_bytes. This must be bound by
+// bytes, not wall-clock time: at high throughput even a sub-second interval
+// buffers megabytes, far past the datagram size limit.
+const YIELD_BYTES = bufferSize ?? 32 * 1024;  // mirror the writer default when unset
 // Approximate on-wire size of one tagged counter line, e.g.
 // "c:sample.counter,location=unix,version=correct-horse-battery-staple:1\n".
 const LINE_BYTES = `c:sample.counter,location=${writerType},version=correct-horse-battery-staple:1`.length + 1;

--- a/test/sample.ts
+++ b/test/sample.ts
@@ -30,20 +30,24 @@ console.log(`Writer Type: ${writerType}`);
 // Node is single-threaded, so there is only ever one worker driving the loop.
 const numThreads = 1;
 
+const YIELD_INTERVAL_NS = 10n * 1_000_000_000n;
+
 let iterations = 0;
 const start = process.hrtime.bigint();
 const deadline = start + BigInt(MAX_DURATION_SECS) * 1_000_000_000n;
+let nextYield = start + YIELD_INTERVAL_NS;
 
-while (process.hrtime.bigint() < deadline) {
+for (let now = start; now < deadline; now = process.hrtime.bigint()) {
     void counter.increment();
     iterations++;
     // The writer buffers synchronously and only flushes when the event loop
     // runs (timer + chained drains). A fully synchronous loop would block the
     // event loop for the whole run, so nothing would ever be sent and the
     // buffer + promise chain would grow without bound, hanging close(). Yield
-    // periodically so the writer drains and memory stays bounded.
-    if ((iterations & 0xFFFF) === 0) {
+    // every 10 seconds so the writer drains and memory stays bounded.
+    if (now >= nextYield) {
         await new Promise((resolve) => setImmediate(resolve));
+        nextYield = process.hrtime.bigint() + YIELD_INTERVAL_NS;
     }
 }
 

--- a/test/sample.ts
+++ b/test/sample.ts
@@ -3,8 +3,28 @@ import process from "node:process";
 
 const MAX_DURATION_SECS = 2 * 60;
 
-const registry = new Registry(new Config("unix"));
+function printUsage(): void {
+    console.error("Usage: sample [writer_type]");
+    console.error("  writer_type: udp or unix (default is unix)");
+}
+
+const args = process.argv.slice(2);
+if (args.length > 1) {
+    printUsage();
+    process.exit(1);
+}
+
+const writerType = args[0] ?? "unix";
+if (writerType !== "udp" && writerType !== "unix") {
+    console.error(`Invalid writer type: ${writerType}`);
+    printUsage();
+    process.exit(1);
+}
+
+const registry = new Registry(new Config(writerType));
 const counter = registry.counter("sample.counter");
+
+console.log(`Writer Type: ${writerType}`);
 
 // Node is single-threaded, so there is only ever one worker driving the loop.
 const numThreads = 1;

--- a/test/sample.ts
+++ b/test/sample.ts
@@ -23,31 +23,40 @@ if (writerType !== "udp" && writerType !== "unix") {
 }
 
 const registry = new Registry(new Config(writerType));
-const counter = registry.counter("sample.counter");
+const tags = {
+    location: writerType,
+    version: "correct-horse-battery-staple",
+};
 
 console.log(`Writer Type: ${writerType}`);
 
 // Node is single-threaded, so there is only ever one worker driving the loop.
 const numThreads = 1;
 
-const YIELD_INTERVAL_NS = 10n * 1_000_000_000n;
+// The writer buffers each line synchronously and only sends when the event
+// loop runs, flushing the *entire* accumulated buffer as one datagram. A
+// synchronous loop never yields, so the buffer balloons and the first drain
+// tries to send an oversized datagram -> EMSGSIZE ("Message too long"). Yield
+// once we've buffered ~16KB so each datagram stays well under the OS limit.
+// This must be bound by bytes, not wall-clock time: at high throughput even a
+// sub-second interval buffers megabytes, far past the datagram size limit.
+const YIELD_BYTES = 16 * 1024;
+// Approximate on-wire size of one tagged counter line, e.g.
+// "c:sample.counter,location=unix,version=correct-horse-battery-staple:1\n".
+const LINE_BYTES = `c:sample.counter,location=${writerType},version=correct-horse-battery-staple:1`.length + 1;
 
 let iterations = 0;
+let bufferedBytes = 0;
 const start = process.hrtime.bigint();
 const deadline = start + BigInt(MAX_DURATION_SECS) * 1_000_000_000n;
-let nextYield = start + YIELD_INTERVAL_NS;
 
 for (let now = start; now < deadline; now = process.hrtime.bigint()) {
-    void counter.increment();
+    void registry.counter("sample.counter", tags).increment();
     iterations++;
-    // The writer buffers synchronously and only flushes when the event loop
-    // runs (timer + chained drains). A fully synchronous loop would block the
-    // event loop for the whole run, so nothing would ever be sent and the
-    // buffer + promise chain would grow without bound, hanging close(). Yield
-    // every 10 seconds so the writer drains and memory stays bounded.
-    if (now >= nextYield) {
+    bufferedBytes += LINE_BYTES;
+    if (bufferedBytes >= YIELD_BYTES) {
         await new Promise((resolve) => setImmediate(resolve));
-        nextYield = process.hrtime.bigint() + YIELD_INTERVAL_NS;
+        bufferedBytes = 0;
     }
 }
 

--- a/test/sample.ts
+++ b/test/sample.ts
@@ -1,5 +1,6 @@
 import {Config, Registry} from "../src/index.js";
 import process from "node:process";
+import {setImmediate} from "node:timers";
 
 const MAX_DURATION_SECS = 2 * 60;
 
@@ -36,6 +37,14 @@ const deadline = start + BigInt(MAX_DURATION_SECS) * 1_000_000_000n;
 while (process.hrtime.bigint() < deadline) {
     void counter.increment();
     iterations++;
+    // The writer buffers synchronously and only flushes when the event loop
+    // runs (timer + chained drains). A fully synchronous loop would block the
+    // event loop for the whole run, so nothing would ever be sent and the
+    // buffer + promise chain would grow without bound, hanging close(). Yield
+    // periodically so the writer drains and memory stays bounded.
+    if ((iterations & 0xFFFF) === 0) {
+        await new Promise((resolve) => setImmediate(resolve));
+    }
 }
 
 const elapsed = Number(process.hrtime.bigint() - start) / 1e9;

--- a/test/sample_hot.ts
+++ b/test/sample_hot.ts
@@ -1,0 +1,95 @@
+// Hot-loop throughput benchmark — a variant of sample.ts.
+//
+// sample.ts constructs a new counter every iteration, so its rate is dominated
+// by per-call meter creation (Id construction + tag validation). This file
+// instead reuses a single counter and just calls increment() in a hot loop, so
+// it measures the increment + buffer path with meter creation removed. The
+// buffer size is controllable via the second argument, exactly like sample.ts.
+import {Config, Registry} from "../src/index.js";
+import process from "node:process";
+import {setImmediate} from "node:timers";
+
+const MAX_DURATION_SECS = 2 * 60;
+
+function printUsage(): void {
+    console.error("Usage: sample_hot [writer_type] [buffer_size_bytes]");
+    console.error("  writer_type: udp or unix (default is unix)");
+    console.error("  buffer_size_bytes: positive integer (default is the writer default, 32768)");
+}
+
+const args = process.argv.slice(2);
+if (args.length > 2) {
+    printUsage();
+    process.exit(1);
+}
+
+const writerType = args[0] ?? "unix";
+if (writerType !== "udp" && writerType !== "unix") {
+    console.error(`Invalid writer type: ${writerType}`);
+    printUsage();
+    process.exit(1);
+}
+
+let bufferSize: number | undefined;
+if (args[1] !== undefined) {
+    bufferSize = Number(args[1]);
+    if (!Number.isInteger(bufferSize) || bufferSize <= 0) {
+        console.error(`Invalid buffer size: ${args[1]}`);
+        printUsage();
+        process.exit(1);
+    }
+}
+
+const registry = new Registry(new Config(writerType, undefined, undefined, bufferSize));
+const tags = {
+    location: writerType,
+    version: "correct-horse-battery-staple",
+};
+// Build the counter once and reuse it — this is the difference from sample.ts.
+const counter = registry.counter("sample.counter", tags);
+
+console.log(`Writer Type: ${writerType}`);
+console.log(`Buffer Size: ${bufferSize ?? "default (32768)"}`);
+
+// Node is single-threaded, so there is only ever one worker driving the loop.
+const numThreads = 1;
+
+// The writer buffers each line synchronously and only sends when the event
+// loop runs, flushing the *entire* accumulated buffer as one datagram. A
+// synchronous loop never yields, so the buffer balloons and the first drain
+// tries to send an oversized datagram -> EMSGSIZE ("Message too long"). Yield
+// once we've buffered roughly one buffer's worth so the writer's size-triggered
+// flush runs and each datagram is ~buffer_size_bytes. This must be bound by
+// bytes, not wall-clock time: at high throughput even a sub-second interval
+// buffers megabytes, far past the datagram size limit.
+const YIELD_BYTES = bufferSize ?? 32 * 1024;  // mirror the writer default when unset
+// Approximate on-wire size of one tagged counter line, e.g.
+// "c:sample.counter,location=unix,version=correct-horse-battery-staple:1\n".
+const LINE_BYTES = `c:sample.counter,location=${writerType},version=correct-horse-battery-staple:1`.length + 1;
+
+let iterations = 0;
+let bufferedBytes = 0;
+const start = process.hrtime.bigint();
+const deadline = start + BigInt(MAX_DURATION_SECS) * 1_000_000_000n;
+
+for (let now = start; now < deadline; now = process.hrtime.bigint()) {
+    void counter.increment();
+    iterations++;
+    bufferedBytes += LINE_BYTES;
+    if (bufferedBytes >= YIELD_BYTES) {
+        await new Promise((resolve) => setImmediate(resolve));
+        bufferedBytes = 0;
+    }
+}
+
+const elapsed = Number(process.hrtime.bigint() - start) / 1e9;
+const rate = iterations / elapsed;
+
+console.log("\nPerformance Test Summary:");
+console.log(`Threads used: ${numThreads}`);
+console.log(`Iterations completed: ${iterations}`);
+console.log(`Total elapsed time: ${elapsed.toFixed(2)} seconds`);
+console.log(`Rate: ${rate.toFixed(2)} iterations/second`);
+console.log(`Rate per thread: ${(rate / numThreads).toFixed(2)} iterations/second/thread`);
+
+await registry.close();

--- a/test/writer/udp_writer.test.ts
+++ b/test/writer/udp_writer.test.ts
@@ -125,6 +125,30 @@ describe("UdpWriter Tests", (): void => {
         }
     });
 
+    it("registry forwards buffer size", async (): Promise<void> => {
+        // A small buffer configured via Config should reach the UdpWriter: two
+        // small increments (~68 bytes) exceed it and trigger a size-based flush
+        // within the sleep window. If the size were not forwarded, the default
+        // 32KB buffer would hold the lines until the 15s timer, and nothing
+        // would arrive in time — so this asserts the Config -> writer wiring.
+        const r = new Registry(new Config(location, undefined, undefined, 50));
+
+        try {
+            await r.counter("server.numRequests", {"id": "success"}).increment();
+            await r.counter("server.numRequests", {"id": "success"}).increment(2);
+
+            await sleep(50);
+
+            const lines = messages.flatMap((m) => m.split("\n"));
+            assert.equal(lines.length, 2);
+            assert.equal(lines[0], "c:server.numRequests,id=success:1");
+            assert.equal(lines[1], "c:server.numRequests,id=success:2");
+        } finally {
+            await r.close();
+            messages.length = 0;
+        }
+    });
+
     it("flush on timeout twice", async (): Promise<void> => {
         const address = server.address();
         const writer = new UdpWriter(location, address.address, address.port, undefined, 8192, 50);


### PR DESCRIPTION
Expose configurable writer buffer size through Config

Adds an optional buffer_size_bytes parameter to Config that is validated as a positive integer and plumbed through Registry and new_writer to the UDP and UDS writers' maxBufferBytes (non-buffering writers ignore it), defaulting to the existing 32768 when omitted. Also reworks the test/sample.ts performance harness to accept writer_type and buffer_size_bytes CLI arguments, report throughput statistics, and yield to the event loop by buffered-byte volume so the buffered writers actually flush instead of accumulating an unbounded backlog. Includes Config unit tests for the new option and a UdpWriter test asserting the size is forwarded end-to-end from Config to the writer.