### PR TITLE
Remove UDS Writer From Config And String/Type Check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nflx-spectator",
-  "version": "3.1.0-rc.8",
+  "version": "3.1.0-rc.9",
   "license": "Apache-2.0",
   "homepage": "https://github.com/Netflix/spectator-js",
   "author": "Netflix Telemetry Engineering <netflix-atlas@googlegroups.com>",

--- a/src/common_tags.ts
+++ b/src/common_tags.ts
@@ -28,9 +28,11 @@ export function tags_from_env_vars(): Record<string, string> {
 export function validate_tags(tags: Record<string, string>): Record<string, string> {
     const valid_tags: Record<string, string> = {};
 
-    for (const key in tags) {
-        const val = tags[key];
-        if (typeof key !== "string" || typeof val !== "string") continue;
+    for (let key in tags) {
+        let val = tags[key];
+        // javascript protection checks
+        if (typeof key !== "string") key = String(key);
+        if (typeof val !== "string") val = String(val);
         if (key.length < 2 || key.length > 60 || val.length < 1 || val.length > 120) continue;
         valid_tags[key] = val;
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,25 +17,20 @@ export class Config {
      *   * `memory` - Write metrics to memory. Useful for testing.
      *   * `stderr` - Write metrics to standard error.
      *   * `stdout` - Write metrics to standard output.
-     *   * `udp`    - Write metrics to the default spectatord UDP port.
-     *   * `unix`   - Write metrics to the default spectatord UDS path (/run/spectatord/spectatord.unix). This is the default value.
+     *   * `udp`    - Write metrics to the default spectatord UDP port. This is the default value.
      *   * `file:///path/to/file`   - Write metrics to a file.
      *   * `udp://host:port`        - Write metrics to a UDP socket.
-     *   * `unix:///path/to/socket` - Write metrics to a SOCK_DGRAM Unix domain socket.
+     *
+     * NOTE: UDS locations (`unix` / `unix:///path/to/socket`) are temporarily not accepted. The
+     * UdsWriter implementation is retained, but these locations are rejected as invalid for now.
      *
      * The output location can be overridden by configuring an environment variable SPECTATOR_OUTPUT_LOCATION
      * with one of the values listed above. Overriding the output location may be useful for integration testing.
      *
-     * The optional `buffer_size_bytes` controls how many bytes the UDP and UDS writers accumulate before
+     * The optional `buffer_size_bytes` controls how many bytes the UDP writer accumulates before
      * flushing a batched datagram; it is ignored by the non-buffering writers (memory, file, etc.). When
      * omitted, the writer default (32768) is used. Lower values flush sooner (smaller datagrams, more
      * syscalls); higher values batch more aggressively. Must be a positive integer if provided.
-     *
-     * UDS support is provided by the `node-unix-socket` package (napi-rs based, ships prebuilt binaries
-     * for common Linux/macOS targets — no node-gyp / build toolchain required at install time). spectatord's
-     * UDS endpoint accepts SOCK_DGRAM datagrams and supports higher throughput than the UDP listener
-     * (~1M req/sec with batching vs ~430K req/sec for UDP). Use `unix` / `unix://...` if your workload
-     * is hot enough to benefit from it.
      */
 
     location: string;
@@ -43,7 +38,7 @@ export class Config {
     logger: Logger;
     buffer_size_bytes?: number;
 
-    constructor(location: string = "unix", extra_common_tags: Tags = {}, logger: Logger = get_logger(),
+    constructor(location: string = "udp", extra_common_tags: Tags = {}, logger: Logger = get_logger(),
                 buffer_size_bytes?: number) {
         this.location = this.calculate_location(location);
         this.extra_common_tags = this.calculate_extra_common_tags(extra_common_tags);

--- a/src/writer/new_writer.ts
+++ b/src/writer/new_writer.ts
@@ -11,10 +11,12 @@ import {StdoutWriter} from "./stdout_writer.js";
 export type WriterUnion = FileWriter | MemoryWriter | NoopWriter | StderrWriter | StdoutWriter | UdpWriter | UdsWriter;
 
 export function is_valid_output_location(location: string): boolean {
-    return ["none", "memory", "stderr", "stdout", "udp", "unix"].includes(location) ||
+    // NOTE: "unix" / "unix://" (UDS) are intentionally not accepted for the time
+    // being. The UdsWriter implementation is retained (see uds_writer.ts and the
+    // routing in new_writer below) so it can be re-enabled by restoring these entries.
+    return ["none", "memory", "stderr", "stdout", "udp"].includes(location) ||
         location.startsWith("file://") ||
-        location.startsWith("udp://") ||
-        location.startsWith("unix://");
+        location.startsWith("udp://");
 }
 
 export function new_writer(location: string, logger?: Logger, buffer_size_bytes?: number): WriterUnion {
@@ -41,9 +43,6 @@ export function new_writer(location: string, logger?: Logger, buffer_size_bytes?
     if (location == "udp") {
         location = "udp://127.0.0.1:1234";
     }
-    if (location == "unix") {
-        location = "unix:///run/spectatord/spectatord.unix";
-    }
     if (location.startsWith("file://")) {
         return new FileWriter(location, log);
     }
@@ -53,25 +52,30 @@ export function new_writer(location: string, logger?: Logger, buffer_size_bytes?
         const hostname = parsed.hostname.replace("[::1]", "::1");
         return new UdpWriter(location, hostname, Number(parsed.port), log, buffer_size_bytes);
     }
-    if (location.startsWith("unix://")) {
-        // unix:///abs/path/socket — strip the scheme to get the filesystem path.
-        const path = location.slice("unix://".length);
-        try {
-            return new UdsWriter(location, path, log, buffer_size_bytes);
-        } catch (err) {
-            // UDS init only really fails when the spectatord socket is missing
-            // or the client bind path isn't writable — both signal "this host
-            // has no spectatord." Fall back to UDP so tests and dev
-            // environments behave like the historical UDP default (silent
-            // drop) instead of crashing at Registry construction. The
-            // underlying errno isn't reliably preserved across the
-            // statSync/node-unix-socket boundary (node-unix-socket surfaces
-            // bind errors with code='Unknown'), so we can't narrow by code —
-            // catching all errors here is intentional.
-            log.warn(`UDS unavailable (${(err as Error).message}); falling back to udp://127.0.0.1:1234`);
-            return new UdpWriter("udp://127.0.0.1:1234", "127.0.0.1", 1234, log, buffer_size_bytes);
-        }
-    }
+    // UDS ("unix" / "unix://...") routing is intentionally disabled for the time
+    // being. is_valid_output_location rejects those locations before we get here,
+    // so this is unreachable, but the routing is preserved (commented out) alongside
+    // the retained UdsWriter implementation to make re-enabling a one-step change.
+    //
+    // if (location.startsWith("unix://")) {
+    //     // unix:///abs/path/socket — strip the scheme to get the filesystem path.
+    //     const path = location.slice("unix://".length);
+    //     try {
+    //         return new UdsWriter(location, path, log, buffer_size_bytes);
+    //     } catch (err) {
+    //         // UDS init only really fails when the spectatord socket is missing
+    //         // or the client bind path isn't writable — both signal "this host
+    //         // has no spectatord." Fall back to UDP so tests and dev
+    //         // environments behave like the historical UDP default (silent
+    //         // drop) instead of crashing at Registry construction. The
+    //         // underlying errno isn't reliably preserved across the
+    //         // statSync/node-unix-socket boundary (node-unix-socket surfaces
+    //         // bind errors with code='Unknown'), so we can't narrow by code —
+    //         // catching all errors here is intentional.
+    //         log.warn(`UDS unavailable (${(err as Error).message}); falling back to udp://127.0.0.1:1234`);
+    //         return new UdpWriter("udp://127.0.0.1:1234", "127.0.0.1", 1234, log, buffer_size_bytes);
+    //     }
+    // }
 
     throw new Error(`unsupported Writer location: ${location}`);
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -32,7 +32,7 @@ describe("Config Tests", (): void => {
         setup_environment();
         const config = new Config();
         assert.deepEqual(all_expected_tags(), config.extra_common_tags);
-        assert.equal(config.location, "unix");
+        assert.equal(config.location, "udp");
         clear_environment();
     });
 
@@ -52,7 +52,7 @@ describe("Config Tests", (): void => {
     it("extra common tags", (): void => {
         setup_environment();
         const config = new Config(undefined, {"extra-tag": "foo"});
-        assert.equal(config.location, "unix");
+        assert.equal(config.location, "udp");
         assert.deepEqual(config.extra_common_tags, {"extra-tag": "foo", "nf.container": "main", "nf.process": "nodejs"});
         clear_environment();
     });

--- a/test/writer/uds_writer.test.ts
+++ b/test/writer/uds_writer.test.ts
@@ -1,5 +1,5 @@
 import {assert} from "chai";
-import {Config, new_writer, Registry, UdsWriter} from "../../src/index.js";
+import {Config, Registry, UdsWriter} from "../../src/index.js";
 import {DgramSocket} from "node-unix-socket";
 import {after, before, describe, it} from "node:test";
 import {tmpdir} from "node:os";
@@ -39,7 +39,9 @@ describe("UdsWriter Tests", (): void => {
     });
 
     it("send metrics", async (): Promise<void> => {
-        const writer = new_writer(location) as UdsWriter;
+        // UDS routing through new_writer is temporarily disabled, so construct the
+        // retained UdsWriter implementation directly rather than via new_writer(location).
+        const writer = new UdsWriter(location, serverPath);
 
         await writer.write("c:server.numRequests,id=failed:1");
         await writer.write("c:server.numRequests,id=failed:2");
@@ -55,7 +57,9 @@ describe("UdsWriter Tests", (): void => {
         messages.length = 0;
     });
 
-    it("using registry", async (): Promise<void> => {
+    // Skipped while UDS locations are rejected by Config / new_writer. This exercises
+    // the disabled routing path (unix:// -> UdsWriter); re-enable alongside that routing.
+    it.skip("using registry", async (): Promise<void> => {
         const r = new Registry(new Config(location));
 
         await r.counter("server.numRequests", {"id": "success"}).increment();


### PR DESCRIPTION
Remove the UDS writer from selection due to CPU usage statistics from canary tests. Add type check and string conversion for incoming tags.